### PR TITLE
Add warp teleportation, player gating, and quest chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
 
     <name>fishingplugin</name>
 
-    <properties>
-        <java.version>17</java.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+      <properties>
+          <java.version>17</java.version>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      </properties>
 
     <build>
         <defaultGoal>clean package</defaultGoal>
@@ -57,12 +57,33 @@
         </repository>
     </repositories>
 
-    <dependencies>
-        <dependency>
-            <groupId>io.papermc.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-</project>
+      <dependencies>
+          <dependency>
+              <groupId>io.papermc.paper</groupId>
+              <artifactId>paper-api</artifactId>
+              <version>1.20.1-R0.1-SNAPSHOT</version>
+              <scope>provided</scope>
+          </dependency>
+          <dependency>
+              <groupId>net.milkbowl.vault</groupId>
+              <artifactId>VaultAPI</artifactId>
+              <version>1.7</version>
+              <scope>provided</scope>
+          </dependency>
+          <dependency>
+              <groupId>com.zaxxer</groupId>
+              <artifactId>HikariCP</artifactId>
+              <version>5.1.0</version>
+          </dependency>
+          <dependency>
+              <groupId>org.flywaydb</groupId>
+              <artifactId>flyway-core</artifactId>
+              <version>10.11.0</version>
+          </dependency>
+          <dependency>
+              <groupId>net.kyori</groupId>
+              <artifactId>adventure-api</artifactId>
+              <version>4.17.0</version>
+          </dependency>
+      </dependencies>
+  </project>

--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -1,17 +1,111 @@
 package org.maks.fishingPlugin;
 
+import java.util.EnumMap;
+import java.util.Map;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.fishingPlugin.listener.FishingListener;
+import org.maks.fishingPlugin.listener.QteListener;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.LootEntry;
+import org.maks.fishingPlugin.model.ScaleConf;
+import org.maks.fishingPlugin.model.ScaleMode;
+import org.maks.fishingPlugin.service.LevelService;
+import org.maks.fishingPlugin.service.LootService;
+import org.maks.fishingPlugin.service.Awarder;
+import org.maks.fishingPlugin.service.QteService;
+import org.maks.fishingPlugin.service.AntiCheatService;
+import org.maks.fishingPlugin.service.QuickSellService;
+import org.maks.fishingPlugin.service.TeleportService;
+import org.maks.fishingPlugin.service.QuestChainService;
+import org.maks.fishingPlugin.command.FishingCommand;
+import net.milkbowl.vault.economy.Economy;
 
 public final class FishingPlugin extends JavaPlugin {
 
+    private LevelService levelService;
+    private LootService lootService;
+    private Awarder awarder;
+    private QuickSellService quickSellService;
+    private TeleportService teleportService;
+    private QteService qteService;
+    private AntiCheatService antiCheatService;
+    private QuestChainService questService;
+    private Economy economy;
+    private int requiredPlayerLevel;
+
     @Override
     public void onEnable() {
-        // Plugin startup logic
+        // Initialize services
+        this.levelService = new LevelService(this);
+        saveDefaultConfig();
+        this.requiredPlayerLevel = getConfig().getInt("player_level_requirement", 80);
 
+        Map<Category, ScaleConf> scaling = new EnumMap<>(Category.class);
+        var scaleSec = getConfig().getConfigurationSection("rare_weight_scaling");
+        if (scaleSec != null) {
+            for (String catKey : scaleSec.getKeys(false)) {
+                try {
+                    Category cat = Category.valueOf(catKey.toUpperCase());
+                    var conf = scaleSec.getConfigurationSection(catKey);
+                    if (conf != null) {
+                        ScaleMode mode = ScaleMode.valueOf(conf.getString("mode", "EXP").toUpperCase());
+                        double param;
+                        if (mode == ScaleMode.EXP) {
+                            param = conf.getDouble("beta");
+                        } else { // POLY
+                            param = conf.getDouble("alpha");
+                        }
+                        double k = conf.getDouble("k", 0);
+                        scaling.put(cat, new ScaleConf(mode, param, k));
+                    }
+                } catch (IllegalArgumentException ignored) {
+                    // ignore invalid categories or modes
+                }
+            }
+        }
+        this.lootService = new LootService(scaling);
+        this.economy = Bukkit.getServicesManager().getRegistration(Economy.class).getProvider();
+        this.awarder = new Awarder(this);
+        var econSec = getConfig().getConfigurationSection("economy");
+        double multiplier = 1.0;
+        double tax = 0.0;
+        String symbol = "$";
+        if (econSec != null) {
+            multiplier = econSec.getDouble("global_multiplier", 1.0);
+            tax = econSec.getDouble("quicksell_tax", 0.0);
+            symbol = econSec.getString("currency_symbol", "$");
+        }
+        this.quickSellService = new QuickSellService(this, lootService, economy, multiplier, tax, symbol);
+        this.teleportService = new TeleportService(this);
+        this.antiCheatService = new AntiCheatService();
+        this.qteService = new QteService(antiCheatService);
+        this.questService = new QuestChainService(economy);
+
+        // Sample loot entries to demonstrate rolling
+        lootService.addEntry(new LootEntry("fish_cod", Category.FISH, 9500, 0, false, 2, 8, 1, 500, 3000, null));
+        lootService.addEntry(new LootEntry("premium_shark", Category.FISH_PREMIUM, 350, 0, false, 10, 20, 1.5, 1000, 5000, null));
+        lootService.addEntry(new LootEntry("ancient_rune", Category.RUNE, 80, 0, true, 0, 0, 1, 0, 0, null));
+
+        Bukkit.getPluginManager().registerEvents(
+            new FishingListener(lootService, awarder, levelService, qteService, questService, requiredPlayerLevel), this);
+        Bukkit.getPluginManager().registerEvents(new QteListener(qteService), this);
+        getCommand("fishing").setExecutor(
+            new FishingCommand(quickSellService, teleportService, questService, levelService, requiredPlayerLevel));
+
+        getLogger().info("FishingPlugin enabled");
+    }
+
+    public LevelService getLevelService() {
+        return levelService;
+    }
+
+    public LootService getLootService() {
+        return lootService;
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        getLogger().info("FishingPlugin disabled");
     }
 }

--- a/src/main/java/org/maks/fishingPlugin/command/FishingCommand.java
+++ b/src/main/java/org/maks/fishingPlugin/command/FishingCommand.java
@@ -1,0 +1,66 @@
+package org.maks.fishingPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.service.QuickSellService;
+import org.maks.fishingPlugin.service.TeleportService;
+import org.maks.fishingPlugin.service.QuestChainService;
+import org.maks.fishingPlugin.service.LevelService;
+
+/**
+ * Basic command handler with a quick sell subcommand.
+ */
+public class FishingCommand implements CommandExecutor {
+
+  private final QuickSellService quickSellService;
+  private final TeleportService teleportService;
+  private final QuestChainService questService;
+  private final LevelService levelService;
+  private final int requiredLevel;
+
+  public FishingCommand(QuickSellService quickSellService, TeleportService teleportService,
+      QuestChainService questService, LevelService levelService,
+      int requiredLevel) {
+    this.quickSellService = quickSellService;
+    this.teleportService = teleportService;
+    this.questService = questService;
+    this.levelService = levelService;
+    this.requiredLevel = requiredLevel;
+  }
+
+  @Override
+  public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    if (!(sender instanceof Player player)) {
+      sender.sendMessage("Only players can use this command.");
+      return true;
+    }
+    if (player.getLevel() < requiredLevel) {
+      player.sendMessage("You need level " + requiredLevel + " to use fishing features.");
+      return true;
+    }
+    if (args.length > 0) {
+      if (args[0].equalsIgnoreCase("sell")) {
+        double amount = quickSellService.sellAll(player);
+        player.sendMessage("Sold fish for " + quickSellService.currencySymbol()
+            + String.format("%.2f", amount));
+        return true;
+      }
+      if (args[0].equalsIgnoreCase("warp") && args.length > 1) {
+        if (teleportService.teleport(args[1], player)) {
+          player.sendMessage("Teleported to " + args[1]);
+        } else {
+          player.sendMessage("Unknown warp " + args[1]);
+        }
+        return true;
+      }
+      if (args[0].equalsIgnoreCase("quest")) {
+        questService.claim(player);
+        return true;
+      }
+    }
+    player.sendMessage("Usage: /" + label + " sell|warp <key>|quest");
+    return true;
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
@@ -1,0 +1,72 @@
+package org.maks.fishingPlugin.listener;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.maks.fishingPlugin.model.LootEntry;
+import org.maks.fishingPlugin.service.Awarder;
+import org.maks.fishingPlugin.service.LevelService;
+import org.maks.fishingPlugin.service.LootService;
+import org.maks.fishingPlugin.service.QteService;
+import org.maks.fishingPlugin.service.QuestChainService;
+
+/**
+ * Listener replacing vanilla fishing drops with custom loot.
+ */
+public class FishingListener implements Listener {
+
+  private final LootService lootService;
+  private final Awarder awarder;
+  private final LevelService levelService;
+  private final QteService qteService;
+  private final QuestChainService questService;
+  private final int requiredLevel;
+
+  public FishingListener(LootService lootService, Awarder awarder, LevelService levelService,
+      QteService qteService, QuestChainService questService, int requiredLevel) {
+    this.lootService = lootService;
+    this.awarder = awarder;
+    this.levelService = levelService;
+    this.qteService = qteService;
+    this.questService = questService;
+    this.requiredLevel = requiredLevel;
+  }
+
+  @EventHandler
+  public void onFish(PlayerFishEvent event) {
+    Player player = event.getPlayer();
+    if (event.getState() == PlayerFishEvent.State.FISHING) {
+      if (player.getLevel() < requiredLevel) {
+        player.sendMessage("You need level " + requiredLevel + " to fish.");
+        event.setCancelled(true);
+      }
+      return;
+    }
+    if (event.getState() == PlayerFishEvent.State.BITE) {
+      qteService.start(player);
+      return;
+    }
+    if (event.getState() != PlayerFishEvent.State.CAUGHT_FISH) {
+      return;
+    }
+    event.setCancelled(true);
+    if (!qteService.consume(player)) {
+      player.sendMessage("Branie uciekło!");
+      return;
+    }
+    int rodLevel = levelService.getLevel(player);
+    LootEntry loot = lootService.roll(rodLevel);
+    Awarder.AwardResult res = awarder.give(player, loot);
+    if (res.item() != null) {
+      double kg = res.weightG() / 1000.0;
+      player.sendMessage("You caught a fish weighing " + String.format("%.1f", kg) + "kg");
+      int before = rodLevel;
+      int after = levelService.awardCatchExp(player, kg, true);
+      if (after > before) {
+        player.sendMessage("Your fishing rod leveled up to " + after + "!");
+      }
+      questService.onCatch(player);
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/listener/QteListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/QteListener.java
@@ -1,0 +1,37 @@
+package org.maks.fishingPlugin.listener;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.maks.fishingPlugin.service.QteService;
+
+/**
+ * Captures player clicks during QTE windows.
+ */
+public class QteListener implements Listener {
+
+  private final QteService qte;
+
+  public QteListener(QteService qte) {
+    this.qte = qte;
+  }
+
+  @EventHandler
+  public void onInteract(PlayerInteractEvent event) {
+    Action action = event.getAction();
+    if (action != Action.LEFT_CLICK_AIR && action != Action.LEFT_CLICK_BLOCK &&
+        action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+      return;
+    }
+    ItemStack item = event.getItem();
+    if (item == null || item.getType() != Material.FISHING_ROD) {
+      return;
+    }
+    QteService.ClickType type = (action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)
+        ? QteService.ClickType.LEFT : QteService.ClickType.RIGHT;
+    qte.handleClick(event.getPlayer(), type);
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/model/Category.java
+++ b/src/main/java/org/maks/fishingPlugin/model/Category.java
@@ -1,0 +1,13 @@
+package org.maks.fishingPlugin.model;
+
+/**
+ * Loot categories available in the fishing system.
+ */
+public enum Category {
+  FISH,
+  FISH_PREMIUM,
+  RUNE,
+  TREASURE,
+  FISHERMAN_CHEST,
+  MATERIAL
+}

--- a/src/main/java/org/maks/fishingPlugin/model/LootEntry.java
+++ b/src/main/java/org/maks/fishingPlugin/model/LootEntry.java
@@ -1,0 +1,19 @@
+package org.maks.fishingPlugin.model;
+
+/**
+ * Definition of a loot item stored in cache/DB.
+ * This is a simplified model used for the initial implementation.
+ */
+public record LootEntry(
+    String key,
+    Category category,
+    double baseWeight,
+    int minRodLevel,
+    boolean broadcast,
+    double priceBase,
+    double pricePerKg,
+    double payoutMultiplier,
+    double minWeightG,
+    double maxWeightG,
+    String itemBase64
+) {}

--- a/src/main/java/org/maks/fishingPlugin/model/QuestStage.java
+++ b/src/main/java/org/maks/fishingPlugin/model/QuestStage.java
@@ -1,0 +1,5 @@
+package org.maks.fishingPlugin.model;
+
+/** Simple quest stage definition with goal and reward. */
+public record QuestStage(int stage, int goal, double reward) {
+}

--- a/src/main/java/org/maks/fishingPlugin/model/ScaleConf.java
+++ b/src/main/java/org/maks/fishingPlugin/model/ScaleConf.java
@@ -1,0 +1,25 @@
+package org.maks.fishingPlugin.model;
+
+/**
+ * Configuration for weight scaling formulas.
+ * <p>
+ * EXP: multiplier = exp(a * level)
+ * POLY: multiplier = (1 + a * level)^k
+ * </p>
+ *
+ * @param mode scaling mode
+ * @param a    parameter (beta for EXP, alpha for POLY)
+ * @param k    exponent for POLY, unused for EXP
+ */
+public record ScaleConf(ScaleMode mode, double a, double k) {
+
+  /**
+   * Computes the multiplier for a given rod level.
+   */
+  public double mult(int level) {
+    return switch (mode) {
+      case EXP -> Math.exp(a * level);
+      case POLY -> Math.pow(1.0 + a * level, k);
+    };
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/model/ScaleMode.java
+++ b/src/main/java/org/maks/fishingPlugin/model/ScaleMode.java
@@ -1,0 +1,9 @@
+package org.maks.fishingPlugin.model;
+
+/**
+ * Modes of scaling loot weights with rod level.
+ */
+public enum ScaleMode {
+  EXP,
+  POLY
+}

--- a/src/main/java/org/maks/fishingPlugin/model/Warp.java
+++ b/src/main/java/org/maks/fishingPlugin/model/Warp.java
@@ -1,0 +1,18 @@
+package org.maks.fishingPlugin.model;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public record Warp(String key, WarpType type, String command, String world, double x, double y, double z) {
+
+  public void teleport(Player player) {
+    if (type == WarpType.COMMAND) {
+      String cmd = command.replace("%player%", player.getName());
+      Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
+    } else if (type == WarpType.COORDS) {
+      Location loc = new Location(Bukkit.getWorld(world), x, y, z);
+      player.teleport(loc);
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/model/WarpType.java
+++ b/src/main/java/org/maks/fishingPlugin/model/WarpType.java
@@ -1,0 +1,6 @@
+package org.maks.fishingPlugin.model;
+
+public enum WarpType {
+  COMMAND,
+  COORDS
+}

--- a/src/main/java/org/maks/fishingPlugin/service/AntiCheatService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/AntiCheatService.java
@@ -1,0 +1,61 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Detects highly regular click intervals indicative of macros.
+ */
+public class AntiCheatService {
+
+  private final Map<UUID, Long> lastClick = new ConcurrentHashMap<>();
+  private final Map<UUID, Deque<Long>> intervals = new ConcurrentHashMap<>();
+  private final int sampleSize;
+  private final long toleranceMs;
+
+  public AntiCheatService(int sampleSize, long toleranceMs) {
+    this.sampleSize = sampleSize;
+    this.toleranceMs = toleranceMs;
+  }
+
+  public AntiCheatService() {
+    this(5, 30); // defaults
+  }
+
+  /**
+   * Record a click timestamp. Returns true if the recent intervals are
+   * suspiciously constant (difference between max and min below tolerance).
+   */
+  public boolean record(UUID player, long timestamp) {
+    Long last = lastClick.put(player, timestamp);
+    if (last == null) {
+      return false; // first sample
+    }
+    long delta = timestamp - last;
+    Deque<Long> deque = intervals.computeIfAbsent(player, k -> new ArrayDeque<>());
+    deque.addLast(delta);
+    if (deque.size() > sampleSize) {
+      deque.removeFirst();
+    }
+    if (deque.size() < sampleSize) {
+      return false;
+    }
+    long min = Long.MAX_VALUE;
+    long max = Long.MIN_VALUE;
+    for (long d : deque) {
+      if (d < min) min = d;
+      if (d > max) max = d;
+    }
+    return max - min <= toleranceMs;
+  }
+
+  /** Reset stored samples for a player. */
+  public void reset(UUID player) {
+    lastClick.remove(player);
+    intervals.remove(player);
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/service/Awarder.java
+++ b/src/main/java/org/maks/fishingPlugin/service/Awarder.java
@@ -1,0 +1,72 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.Bukkit;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.LootEntry;
+import org.maks.fishingPlugin.util.ItemSerialization;
+
+/**
+ * Grants rolled loot to the player.
+ */
+public class Awarder {
+
+  private final JavaPlugin plugin;
+  private final NamespacedKey keyKey;
+  private final NamespacedKey weightKey;
+
+  public Awarder(JavaPlugin plugin) {
+    this.plugin = plugin;
+    this.keyKey = new NamespacedKey(plugin, "loot-key");
+    this.weightKey = new NamespacedKey(plugin, "weight-g");
+  }
+
+  /** Result of awarding loot. */
+  public record AwardResult(double weightG, ItemStack item) {}
+
+  /**
+   * Give the loot to the player.
+   * If an ItemStack definition is present it will be used; otherwise fish
+   * categories fall back to raw cod items and other categories only send a
+   * message.
+   */
+  public AwardResult give(Player player, LootEntry loot) {
+    ItemStack item = null;
+    if (loot.itemBase64() != null) {
+      item = ItemSerialization.fromBase64(loot.itemBase64());
+    } else if (loot.category() == Category.FISH || loot.category() == Category.FISH_PREMIUM) {
+      item = new ItemStack(Material.COD);
+    }
+
+    if (item == null) {
+      player.sendMessage("You obtained: " + loot.key());
+      return new AwardResult(0, null);
+    }
+
+    ItemMeta meta = item.getItemMeta();
+    double weight = 0;
+    if (meta != null) {
+      PersistentDataContainer pdc = meta.getPersistentDataContainer();
+      pdc.set(keyKey, PersistentDataType.STRING, loot.key());
+      if (loot.category() == Category.FISH || loot.category() == Category.FISH_PREMIUM) {
+        weight = ThreadLocalRandom.current().nextDouble(loot.minWeightG(), loot.maxWeightG());
+        pdc.set(weightKey, PersistentDataType.DOUBLE, weight);
+        meta.setDisplayName(loot.key());
+      }
+      item.setItemMeta(meta);
+    }
+    player.getInventory().addItem(item);
+    if (loot.broadcast()) {
+      Bukkit.broadcastMessage(player.getName() + " obtained " + loot.key() + "!");
+    }
+    return new AwardResult(weight, item);
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/LevelService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LevelService.java
@@ -1,0 +1,80 @@
+package org.maks.fishingPlugin.service;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Handles rod experience calculations and persistence.
+ */
+public class LevelService {
+
+  private final NamespacedKey levelKey;
+  private final NamespacedKey xpKey;
+
+  public LevelService(JavaPlugin plugin) {
+    this.levelKey = new NamespacedKey(plugin, "rod_level");
+    this.xpKey = new NamespacedKey(plugin, "rod_xp");
+  }
+
+  /**
+   * Calculates required experience to reach the next level.
+   * The curve follows the specification without a hard cap.
+   *
+   * @param level current rod level
+   * @return experience needed to reach {@code level + 1}
+   */
+  public long neededExp(int level) {
+    if (level < 15) {
+      return Math.round(150 * Math.pow(1.12, level));
+    }
+    if (level < 30) {
+      return Math.round(150 * Math.pow(1.12, 15) * Math.pow(1.14, level - 15));
+    }
+    return Math.round(150 * Math.pow(1.12, 15) * Math.pow(1.14, 15) * Math.pow(1.16, level - 30));
+  }
+
+  private PersistentDataContainer data(Player p) {
+    return p.getPersistentDataContainer();
+  }
+
+  public int getLevel(Player p) {
+    return data(p).getOrDefault(levelKey, PersistentDataType.INTEGER, 0);
+  }
+
+  public long getXp(Player p) {
+    return data(p).getOrDefault(xpKey, PersistentDataType.LONG, 0L);
+  }
+
+  private void setLevel(Player p, int level) {
+    data(p).set(levelKey, PersistentDataType.INTEGER, level);
+  }
+
+  private void setXp(Player p, long xp) {
+    data(p).set(xpKey, PersistentDataType.LONG, xp);
+  }
+
+  /**
+   * Awards experience for a catch and handles level ups.
+   *
+   * @param p player
+   * @param weightKg weight of the fish in kilograms
+   * @param perfect whether the QTE was perfect
+   * @return new rod level after applying experience
+   */
+  public int awardCatchExp(Player p, double weightKg, boolean perfect) {
+    long gain = Math.round(8 + 0.4 * weightKg + (perfect ? 3 : 0));
+    long xp = getXp(p) + gain;
+    int level = getLevel(p);
+    while (xp >= neededExp(level)) {
+      xp -= neededExp(level);
+      level++;
+    }
+    setXp(p, xp);
+    setLevel(p, level);
+    return level;
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/service/LootService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LootService.java
@@ -1,0 +1,58 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.LootEntry;
+import org.maks.fishingPlugin.model.ScaleConf;
+import org.maks.fishingPlugin.util.WeightedPicker;
+
+/**
+ * Rolls loot using weighted roulette without soft caps.
+ * Loot entries can be registered at runtime; the service applies
+ * scaling multipliers per category depending on rod level.
+ */
+public class LootService {
+
+  private final List<LootEntry> entries = new ArrayList<>();
+  private final Map<Category, ScaleConf> scaling;
+  private final Map<String, LootEntry> byKey = new java.util.HashMap<>();
+
+  public LootService(Map<Category, ScaleConf> scaling) {
+    this.scaling = new EnumMap<>(scaling);
+  }
+
+  /** Register a loot entry. */
+  public void addEntry(LootEntry entry) {
+    entries.add(entry);
+    byKey.put(entry.key(), entry);
+  }
+
+  /**
+   * Rolls a random loot entry based on rod level.
+   */
+  public LootEntry roll(int rodLevel) {
+    if (entries.isEmpty()) {
+      throw new IllegalStateException("No loot entries registered");
+    }
+    WeightedPicker<LootEntry> picker = new WeightedPicker<>(entries,
+        e -> effectiveWeight(e, rodLevel));
+    return picker.pick(ThreadLocalRandom.current());
+  }
+
+  public LootEntry getEntry(String key) {
+    return byKey.get(key);
+  }
+
+  double effectiveWeight(LootEntry e, int rodLevel) {
+    if (rodLevel < e.minRodLevel()) {
+      return 0.0;
+    }
+    ScaleConf conf = scaling.get(e.category());
+    double base = e.baseWeight();
+    return conf == null ? base : base * conf.mult(rodLevel);
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/QteService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QteService.java
@@ -1,0 +1,73 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+
+/**
+ * Simple one-click QTE anti-autofish mechanic.
+ */
+public class QteService {
+
+  public enum ClickType {LEFT, RIGHT}
+
+  private static class State {
+    final ClickType required;
+    final long expiry;
+    boolean success;
+    State(ClickType required, long expiry) {
+      this.required = required;
+      this.expiry = expiry;
+    }
+  }
+
+  private final Map<UUID, State> states = new ConcurrentHashMap<>();
+  private final AntiCheatService antiCheat;
+
+  public QteService(AntiCheatService antiCheat) {
+    this.antiCheat = antiCheat;
+  }
+
+  /** Start a QTE after a bite. */
+  public void start(Player player) {
+    ClickType req = ThreadLocalRandom.current().nextBoolean() ? ClickType.LEFT : ClickType.RIGHT;
+    long expiry = System.currentTimeMillis() + ThreadLocalRandom.current().nextLong(600, 1201);
+    states.put(player.getUniqueId(), new State(req, expiry));
+    String msg = req == ClickType.LEFT ? "Kliknij LPM!" : "Kliknij PPM!";
+    player.sendActionBar(Component.text(msg));
+  }
+
+  /** Handle a player click during the QTE window. */
+  public void handleClick(Player player, ClickType click) {
+    long now = System.currentTimeMillis();
+    if (antiCheat.record(player.getUniqueId(), now)) {
+      states.remove(player.getUniqueId());
+      player.sendMessage("Wykryto makro!");
+      return;
+    }
+    State st = states.get(player.getUniqueId());
+    if (st == null) return;
+    if (now > st.expiry) {
+      states.remove(player.getUniqueId());
+      player.sendMessage("Za późno!");
+      return;
+    }
+    if (click == st.required) {
+      st.success = true; // keep state until consume
+    } else {
+      states.remove(player.getUniqueId());
+      player.sendMessage("Zły przycisk!");
+    }
+  }
+
+  /** Consume the QTE result when the player attempts to reel in. */
+  public boolean consume(Player player) {
+    State st = states.remove(player.getUniqueId());
+    if (st == null) return false;
+    long now = System.currentTimeMillis();
+    return st.success && now <= st.expiry;
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/QuestChainService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QuestChainService.java
@@ -1,0 +1,68 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.model.QuestStage;
+
+/**
+ * Minimal quest chain service with catch-count goals and money rewards.
+ */
+public class QuestChainService {
+
+  private final Economy economy;
+  private final List<QuestStage> stages = new ArrayList<>();
+  private final Map<UUID, Progress> progress = new HashMap<>();
+
+  public QuestChainService(Economy economy) {
+    this.economy = economy;
+    // sample stages
+    stages.add(new QuestStage(1, 5, 100));
+    stages.add(new QuestStage(2, 10, 200));
+    stages.add(new QuestStage(3, 15, 300));
+  }
+
+  /** Call when a player catches a fish. */
+  public void onCatch(Player player) {
+    Progress p = progress.computeIfAbsent(player.getUniqueId(), u -> new Progress());
+    if (p.stage >= stages.size()) {
+      return; // all done
+    }
+    p.count++;
+    QuestStage stage = stages.get(p.stage);
+    if (p.count >= stage.goal()) {
+      player.sendMessage(
+          "Quest stage " + stage.stage() + " complete! Use /fishing quest to claim reward.");
+    }
+  }
+
+  /** Claim reward or show progress if not finished. */
+  public void claim(Player player) {
+    Progress p = progress.computeIfAbsent(player.getUniqueId(), u -> new Progress());
+    if (p.stage >= stages.size()) {
+      player.sendMessage("All quests completed.");
+      return;
+    }
+    QuestStage stage = stages.get(p.stage);
+    if (p.count < stage.goal()) {
+      player.sendMessage(
+          "Catch " + (stage.goal() - p.count) + " more fish to finish quest stage " + stage.stage());
+      return;
+    }
+    economy.depositPlayer(player, stage.reward());
+    player.sendMessage(
+        "Received $" + String.format("%.0f", stage.reward()) +
+            " for completing quest stage " + stage.stage());
+    p.stage++;
+    p.count = 0;
+  }
+
+  private static class Progress {
+    int stage = 0;
+    int count = 0;
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/QuickSellService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QuickSellService.java
@@ -1,0 +1,71 @@
+package org.maks.fishingPlugin.service;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+import net.milkbowl.vault.economy.Economy;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.LootEntry;
+
+/**
+ * Handles quick selling of caught fish.
+ */
+public class QuickSellService {
+
+  private final LootService lootService;
+  private final Economy economy;
+  private final NamespacedKey keyKey;
+  private final NamespacedKey weightKey;
+  private final double globalMultiplier;
+  private final double tax;
+  private final String currencySymbol;
+
+  public QuickSellService(JavaPlugin plugin, LootService lootService, Economy economy,
+      double globalMultiplier, double tax, String currencySymbol) {
+    this.lootService = lootService;
+    this.economy = economy;
+    this.globalMultiplier = globalMultiplier;
+    this.tax = tax;
+    this.currencySymbol = currencySymbol;
+    this.keyKey = new NamespacedKey(plugin, "loot-key");
+    this.weightKey = new NamespacedKey(plugin, "weight-g");
+  }
+
+  /** Sell all fish items in the player's inventory. */
+  public double sellAll(Player player) {
+    double total = 0;
+    ItemStack[] contents = player.getInventory().getContents();
+    for (ItemStack item : contents) {
+      if (item == null) continue;
+      ItemMeta meta = item.getItemMeta();
+      if (meta == null) continue;
+      PersistentDataContainer pdc = meta.getPersistentDataContainer();
+      String key = pdc.get(keyKey, PersistentDataType.STRING);
+      Double weight = pdc.get(weightKey, PersistentDataType.DOUBLE);
+      if (key == null || weight == null) continue;
+      LootEntry entry = lootService.getEntry(key);
+      if (entry == null) continue;
+      if (entry.category() != Category.FISH && entry.category() != Category.FISH_PREMIUM) {
+        continue;
+      }
+      double price = (entry.priceBase() + (weight / 1000.0) * entry.pricePerKg())
+          * entry.payoutMultiplier() * globalMultiplier * item.getAmount();
+      total += price;
+      player.getInventory().removeItem(item);
+    }
+    if (total > 0) {
+      double payout = total * (1.0 - tax);
+      economy.depositPlayer(player, payout);
+      return payout;
+    }
+    return 0;
+  }
+
+  public String currencySymbol() {
+    return currencySymbol;
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/RodService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/RodService.java
@@ -1,0 +1,58 @@
+package org.maks.fishingPlugin.service;
+
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Handles creation and detection of the plugin's fishing rod item.
+ */
+public class RodService {
+
+  private final NamespacedKey rodKey;
+
+  public RodService(JavaPlugin plugin) {
+    this.rodKey = new NamespacedKey(plugin, "fishing-rod");
+  }
+
+  private boolean isRod(ItemStack item) {
+    if (item == null) return false;
+    ItemMeta meta = item.getItemMeta();
+    if (meta == null) return false;
+    return meta.getPersistentDataContainer().has(rodKey, PersistentDataType.BYTE);
+  }
+
+  /**
+   * Checks if the player already has our fishing rod.
+   */
+  public boolean hasRod(Player player) {
+    for (ItemStack item : player.getInventory().getContents()) {
+      if (isRod(item)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Gives the basic fishing rod to the player if they don't already possess it.
+   */
+  public void giveRod(Player player) {
+    if (hasRod(player)) {
+      return;
+    }
+    ItemStack rod = new ItemStack(Material.FISHING_ROD);
+    ItemMeta meta = rod.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName("Fishing Rod");
+      meta.getPersistentDataContainer().set(rodKey, PersistentDataType.BYTE, (byte) 1);
+      rod.setItemMeta(meta);
+    }
+    player.getInventory().addItem(rod);
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/service/TeleportService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/TeleportService.java
@@ -1,0 +1,37 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.fishingPlugin.model.Warp;
+import org.maks.fishingPlugin.model.WarpType;
+
+public class TeleportService {
+
+  private final Map<String, Warp> warps = new HashMap<>();
+
+  public TeleportService(JavaPlugin plugin) {
+    ConfigurationSection sec = plugin.getConfig();
+    List<Map<?, ?>> list = sec.getMapList("warps");
+    for (Map<?, ?> m : list) {
+      String key = (String) m.get("key");
+      String typeStr = (String) m.get("type");
+      WarpType type = WarpType.valueOf(typeStr.toUpperCase());
+      String command = (String) m.getOrDefault("command", "");
+      String world = (String) m.getOrDefault("world", "world");
+      double x = ((Number) m.getOrDefault("x", 0)).doubleValue();
+      double y = ((Number) m.getOrDefault("y", 0)).doubleValue();
+      double z = ((Number) m.getOrDefault("z", 0)).doubleValue();
+      warps.put(key, new Warp(key, type, command, world, x, y, z));
+    }
+  }
+
+  public boolean teleport(String key, org.bukkit.entity.Player player) {
+    Warp warp = warps.get(key);
+    if (warp == null) return false;
+    warp.teleport(player);
+    return true;
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/util/ItemSerialization.java
+++ b/src/main/java/org/maks/fishingPlugin/util/ItemSerialization.java
@@ -1,0 +1,48 @@
+package org.maks.fishingPlugin.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.io.BukkitObjectInputStream;
+import org.bukkit.util.io.BukkitObjectOutputStream;
+
+/**
+ * Utility for serializing ItemStacks to Base64 and back.
+ */
+public final class ItemSerialization {
+  private ItemSerialization() {}
+
+  /**
+   * Serializes an ItemStack into a Base64 string.
+   *
+   * @param item the item to serialize
+   * @return base64 representation
+   */
+  public static String toBase64(ItemStack item) {
+    try (var baos = new ByteArrayOutputStream();
+         var oos = new BukkitObjectOutputStream(baos)) {
+      oos.writeObject(item);
+      return Base64.getEncoder().encodeToString(baos.toByteArray());
+    } catch (IOException e) {
+      throw new RuntimeException("Could not serialize item", e);
+    }
+  }
+
+  /**
+   * Deserializes an ItemStack from its Base64 representation.
+   *
+   * @param b64 base64 string
+   * @return deserialized item
+   */
+  public static ItemStack fromBase64(String b64) {
+    byte[] data = Base64.getDecoder().decode(b64);
+    try (var bais = new ByteArrayInputStream(data);
+         var ois = new BukkitObjectInputStream(bais)) {
+      return (ItemStack) ois.readObject();
+    } catch (IOException | ClassNotFoundException e) {
+      throw new RuntimeException("Could not deserialize item", e);
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/util/WeightedPicker.java
+++ b/src/main/java/org/maks/fishingPlugin/util/WeightedPicker.java
@@ -1,0 +1,36 @@
+package org.maks.fishingPlugin.util;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.ToDoubleFunction;
+
+/**
+ * Generic weighted random picker without soft caps.
+ */
+public final class WeightedPicker<T> {
+  private final List<T> entries;
+  private final ToDoubleFunction<T> weightFn;
+
+  public WeightedPicker(List<T> entries, ToDoubleFunction<T> weightFn) {
+    this.entries = List.copyOf(entries);
+    this.weightFn = weightFn;
+  }
+
+  /**
+   * Picks a random entry using roulette-wheel selection.
+   */
+  public T pick(ThreadLocalRandom rnd) {
+    double sum = 0.0;
+    for (T e : entries) {
+      sum += Math.max(0.0, weightFn.applyAsDouble(e));
+    }
+    double r = rnd.nextDouble(sum);
+    for (T e : entries) {
+      double w = Math.max(0.0, weightFn.applyAsDouble(e));
+      if ((r -= w) <= 0) {
+        return e;
+      }
+    }
+    return entries.get(entries.size() - 1);
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,29 @@
+player_level_requirement: 80
+
+economy:
+  currency_symbol: "$"
+  quicksell_tax: 0.0
+  global_multiplier: 1.0
+
+warps:
+  - key: oceanic_pier
+    type: COMMAND
+    command: "warp oceanic_pier %player%"
+  - key: sunken_grotto
+    type: COORDS
+    world: world
+    x: 123.5
+    y: 64
+    z: -210.5
+
+rare_weight_scaling:
+  RUNE:
+    mode: EXP
+    beta: 0.007
+  TREASURE:
+    mode: EXP
+    beta: 0.006
+  FISH_PREMIUM:
+    mode: POLY
+    alpha: 0.015
+    k: 0.9

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,9 @@
 name: FishingPlugin
-version: '1.0-SNAPSHOT'
 main: org.maks.fishingPlugin.FishingPlugin
-api-version: '1.20'
+version: 0.0.1
+api-version: 1.20
+commands:
+  fishing:
+    description: Fishing commands
+    usage: /fishing sell|warp <key>|quest
+    permission: fishing.use


### PR DESCRIPTION
## Summary
- Load warp definitions from config and provide teleportation service
- Add simple QTE anti-autofish check with click interval detection and rod leveling with XP
- Enforce configurable player level requirement before teleporting, quick selling, or casting
- Introduce basic quest chain service with claimable money rewards and `/fishing quest` subcommand
- Allow loot definitions to include Base64 item data and grant those items on catch
- Broadcast special loot to all players when a loot entry is marked for broadcast
- Read rare weight scaling multipliers from config instead of hardcoding values
- Interpret EXP/POLY scaling parameters via `beta`/`alpha` in configuration
- Configure quick sell economy via `economy` section (symbol, tax, global multiplier)
- Remove `/fishing rod` subcommand; rod acquisition will be handled via GUI shop

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e0420b674832a8d84e687f49b244f