### PR TITLE
Add HikariCP data layer and Flyway migrations

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/data/Database.java
+++ b/src/main/java/org/maks/fishingPlugin/data/Database.java
@@ -1,0 +1,34 @@
+package org.maks.fishingPlugin.data;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+
+/**
+ * Simple wrapper around HikariCP for obtaining a {@link DataSource}.
+ */
+public class Database {
+
+  private final HikariDataSource dataSource;
+
+  public Database(String jdbcUrl, String username, String password) {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(jdbcUrl);
+    if (username != null) {
+      config.setUsername(username);
+    }
+    if (password != null) {
+      config.setPassword(password);
+    }
+    this.dataSource = new HikariDataSource(config);
+  }
+
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+
+  public void close() {
+    dataSource.close();
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/data/LootRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/LootRepo.java
@@ -1,0 +1,48 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.LootEntry;
+
+/** Repository providing loot entries. */
+public class LootRepo {
+
+  private final DataSource dataSource;
+
+  public LootRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public List<LootEntry> findAll() throws SQLException {
+    String sql = "SELECT key, category, base_weight, min_rod_level, broadcast, " +
+        "price_base, price_per_kg, payout_multiplier, min_weight_g, max_weight_g, item_base64 FROM loot";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql);
+         ResultSet rs = ps.executeQuery()) {
+      List<LootEntry> list = new ArrayList<>();
+      while (rs.next()) {
+        list.add(new LootEntry(
+            rs.getString(1),
+            Category.valueOf(rs.getString(2)),
+            rs.getDouble(3),
+            rs.getInt(4),
+            rs.getBoolean(5),
+            rs.getDouble(6),
+            rs.getDouble(7),
+            rs.getDouble(8),
+            rs.getDouble(9),
+            rs.getDouble(10),
+            rs.getString(11)
+        ));
+      }
+      return list;
+    }
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/data/ParamRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/ParamRepo.java
@@ -1,0 +1,33 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+
+/** Generic key-value parameter repository. */
+public class ParamRepo {
+
+  private final DataSource dataSource;
+
+  public ParamRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public Map<String, String> findAll() throws SQLException {
+    String sql = "SELECT key, value FROM param";
+    Map<String, String> map = new HashMap<>();
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql);
+         ResultSet rs = ps.executeQuery()) {
+      while (rs.next()) {
+        map.put(rs.getString(1), rs.getString(2));
+      }
+    }
+    return map;
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/data/Profile.java
+++ b/src/main/java/org/maks/fishingPlugin/data/Profile.java
@@ -1,0 +1,7 @@
+package org.maks.fishingPlugin.data;
+
+import java.util.UUID;
+
+/** Player profile persisted in the database. */
+public record Profile(UUID playerUuid, int rodLevel, long rodXp) {}
+

--- a/src/main/java/org/maks/fishingPlugin/data/ProfileRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/ProfileRepo.java
@@ -1,0 +1,45 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import javax.sql.DataSource;
+
+/** Repository for profile data. */
+public class ProfileRepo {
+
+  private final DataSource dataSource;
+
+  public ProfileRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public Optional<Profile> find(UUID uuid) throws SQLException {
+    String sql = "SELECT player_uuid, rod_level, rod_xp FROM profile WHERE player_uuid=?";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, uuid.toString());
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          return Optional.of(new Profile(UUID.fromString(rs.getString(1)), rs.getInt(2), rs.getLong(3)));
+        }
+        return Optional.empty();
+      }
+    }
+  }
+
+  public void upsert(Profile profile) throws SQLException {
+    String sql = "MERGE INTO profile(player_uuid, rod_level, rod_xp) KEY(player_uuid) VALUES(?,?,?)";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, profile.playerUuid().toString());
+      ps.setInt(2, profile.rodLevel());
+      ps.setLong(3, profile.rodXp());
+      ps.executeUpdate();
+    }
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/data/QuestRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/QuestRepo.java
@@ -1,0 +1,34 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.maks.fishingPlugin.model.QuestStage;
+
+/** Repository for quest stage definitions. */
+public class QuestRepo {
+
+  private final DataSource dataSource;
+
+  public QuestRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public List<QuestStage> findAll() throws SQLException {
+    String sql = "SELECT stage, goal, reward FROM quest ORDER BY stage";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql);
+         ResultSet rs = ps.executeQuery()) {
+      List<QuestStage> list = new ArrayList<>();
+      while (rs.next()) {
+        list.add(new QuestStage(rs.getInt(1), rs.getInt(2), rs.getDouble(3)));
+      }
+      return list;
+    }
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/service/QuestChainService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QuestChainService.java
@@ -20,10 +20,12 @@ public class QuestChainService {
 
   public QuestChainService(Economy economy) {
     this.economy = economy;
-    // sample stages
-    stages.add(new QuestStage(1, 5, 100));
-    stages.add(new QuestStage(2, 10, 200));
-    stages.add(new QuestStage(3, 15, 300));
+  }
+
+  /** Replace quest stages with definitions from storage. */
+  public void setStages(List<QuestStage> stages) {
+    this.stages.clear();
+    this.stages.addAll(stages);
   }
 
   /** Call when a player catches a fish. */

--- a/src/main/resources/db/migration/V1__create_tables.sql
+++ b/src/main/resources/db/migration/V1__create_tables.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS profile (
+    player_uuid VARCHAR(36) PRIMARY KEY,
+    rod_level INT NOT NULL,
+    rod_xp BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS loot (
+    key VARCHAR(64) PRIMARY KEY,
+    category VARCHAR(32) NOT NULL,
+    base_weight DOUBLE NOT NULL,
+    min_rod_level INT NOT NULL,
+    broadcast BOOLEAN NOT NULL,
+    price_base DOUBLE NOT NULL,
+    price_per_kg DOUBLE NOT NULL,
+    payout_multiplier DOUBLE NOT NULL,
+    min_weight_g DOUBLE NOT NULL,
+    max_weight_g DOUBLE NOT NULL,
+    item_base64 TEXT
+);
+
+CREATE TABLE IF NOT EXISTS quest (
+    stage INT PRIMARY KEY,
+    goal INT NOT NULL,
+    reward DOUBLE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS param (
+    key VARCHAR(64) PRIMARY KEY,
+    value VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
## Summary
- introduce `data` package with HikariCP database wrapper and repositories for profiles, loot, quests and parameters
- add Flyway migration creating profile, loot, quest and param tables
- initialize database, run Flyway and load repository data into caches during plugin startup
- allow `QuestChainService` to accept quest stages from storage

## Testing
- `mvn -q -e -ntp test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e240e5fb4832aacad931c042203b8