### PR TITLE
Integrate Adventure-based menu system

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -27,7 +27,10 @@ import org.maks.fishingPlugin.service.LootService;
 import org.maks.fishingPlugin.service.QteService;
 import org.maks.fishingPlugin.service.QuestChainService;
 import org.maks.fishingPlugin.service.QuickSellService;
-import org.maks.fishingPlugin.service.TeleportService;
+import org.maks.fishingPlugin.gui.MainMenu;
+import org.maks.fishingPlugin.gui.QuickSellMenu;
+import org.maks.fishingPlugin.gui.RodShopMenu;
+import org.maks.fishingPlugin.gui.QuestMenu;
 import net.milkbowl.vault.economy.Economy;
 
 public final class FishingPlugin extends JavaPlugin {
@@ -36,7 +39,6 @@ public final class FishingPlugin extends JavaPlugin {
     private LootService lootService;
     private Awarder awarder;
     private QuickSellService quickSellService;
-    private TeleportService teleportService;
     private QteService qteService;
     private AntiCheatService antiCheatService;
     private QuestChainService questService;
@@ -118,7 +120,6 @@ public final class FishingPlugin extends JavaPlugin {
         tax = Double.parseDouble(params.getOrDefault("quicksell_tax", String.valueOf(tax)));
         symbol = params.getOrDefault("currency_symbol", symbol);
         this.quickSellService = new QuickSellService(this, lootService, economy, multiplier, tax, symbol);
-        this.teleportService = new TeleportService(this);
         this.antiCheatService = new AntiCheatService();
         this.qteService = new QteService(antiCheatService);
         this.questService = new QuestChainService(economy);
@@ -131,8 +132,12 @@ public final class FishingPlugin extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(
             new FishingListener(lootService, awarder, levelService, qteService, questService, requiredPlayerLevel), this);
         Bukkit.getPluginManager().registerEvents(new QteListener(qteService), this);
-        getCommand("fishing").setExecutor(
-            new FishingCommand(quickSellService, teleportService, questService, levelService, requiredPlayerLevel));
+
+        QuickSellMenu quickSellMenu = new QuickSellMenu(quickSellService);
+        RodShopMenu rodShopMenu = new RodShopMenu();
+        QuestMenu questMenu = new QuestMenu(questService);
+        MainMenu mainMenu = new MainMenu(quickSellMenu, rodShopMenu, questMenu);
+        getCommand("fishing").setExecutor(new FishingCommand(mainMenu, requiredPlayerLevel));
 
         getLogger().info("FishingPlugin enabled");
     }

--- a/src/main/java/org/maks/fishingPlugin/command/FishingCommand.java
+++ b/src/main/java/org/maks/fishingPlugin/command/FishingCommand.java
@@ -4,29 +4,18 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.maks.fishingPlugin.service.QuickSellService;
-import org.maks.fishingPlugin.service.TeleportService;
-import org.maks.fishingPlugin.service.QuestChainService;
-import org.maks.fishingPlugin.service.LevelService;
+import org.maks.fishingPlugin.gui.MainMenu;
 
 /**
- * Basic command handler with a quick sell subcommand.
+ * Command that opens the main fishing menu.
  */
 public class FishingCommand implements CommandExecutor {
 
-  private final QuickSellService quickSellService;
-  private final TeleportService teleportService;
-  private final QuestChainService questService;
-  private final LevelService levelService;
+  private final MainMenu mainMenu;
   private final int requiredLevel;
 
-  public FishingCommand(QuickSellService quickSellService, TeleportService teleportService,
-      QuestChainService questService, LevelService levelService,
-      int requiredLevel) {
-    this.quickSellService = quickSellService;
-    this.teleportService = teleportService;
-    this.questService = questService;
-    this.levelService = levelService;
+  public FishingCommand(MainMenu mainMenu, int requiredLevel) {
+    this.mainMenu = mainMenu;
     this.requiredLevel = requiredLevel;
   }
 
@@ -40,27 +29,7 @@ public class FishingCommand implements CommandExecutor {
       player.sendMessage("You need level " + requiredLevel + " to use fishing features.");
       return true;
     }
-    if (args.length > 0) {
-      if (args[0].equalsIgnoreCase("sell")) {
-        double amount = quickSellService.sellAll(player);
-        player.sendMessage("Sold fish for " + quickSellService.currencySymbol()
-            + String.format("%.2f", amount));
-        return true;
-      }
-      if (args[0].equalsIgnoreCase("warp") && args.length > 1) {
-        if (teleportService.teleport(args[1], player)) {
-          player.sendMessage("Teleported to " + args[1]);
-        } else {
-          player.sendMessage("Unknown warp " + args[1]);
-        }
-        return true;
-      }
-      if (args[0].equalsIgnoreCase("quest")) {
-        questService.claim(player);
-        return true;
-      }
-    }
-    player.sendMessage("Usage: /" + label + " sell|warp <key>|quest");
+    mainMenu.open(player);
     return true;
   }
 }

--- a/src/main/java/org/maks/fishingPlugin/gui/MainMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/MainMenu.java
@@ -1,0 +1,35 @@
+package org.maks.fishingPlugin.gui;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+
+public class MainMenu {
+
+  private final QuickSellMenu quickSellMenu;
+  private final RodShopMenu rodShopMenu;
+  private final QuestMenu questMenu;
+
+  public MainMenu(QuickSellMenu quickSellMenu, RodShopMenu rodShopMenu, QuestMenu questMenu) {
+    this.quickSellMenu = quickSellMenu;
+    this.rodShopMenu = rodShopMenu;
+    this.questMenu = questMenu;
+  }
+
+  public void open(Player player) {
+    Component menu = Component.text()
+        .append(Component.text("Fishing Menu").color(NamedTextColor.AQUA))
+        .append(Component.newline())
+        .append(Component.text("[Quick Sell]").color(NamedTextColor.GREEN)
+            .clickEvent(ClickEvent.callback(audience -> quickSellMenu.open(player))))
+        .append(Component.newline())
+        .append(Component.text("[Rod Shop]").color(NamedTextColor.BLUE)
+            .clickEvent(ClickEvent.callback(audience -> rodShopMenu.open(player))))
+        .append(Component.newline())
+        .append(Component.text("[Quests]").color(NamedTextColor.GOLD)
+            .clickEvent(ClickEvent.callback(audience -> questMenu.open(player))))
+        .build();
+    player.sendMessage(menu);
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/QuestMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/QuestMenu.java
@@ -1,0 +1,26 @@
+package org.maks.fishingPlugin.gui;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.service.QuestChainService;
+
+public class QuestMenu {
+
+  private final QuestChainService questService;
+
+  public QuestMenu(QuestChainService questService) {
+    this.questService = questService;
+  }
+
+  public void open(Player player) {
+    Component menu = Component.text()
+        .append(Component.text("Quests").color(NamedTextColor.GOLD))
+        .append(Component.newline())
+        .append(Component.text("[Claim Reward]").color(NamedTextColor.GREEN)
+            .clickEvent(ClickEvent.callback(audience -> questService.claim(player))))
+        .build();
+    player.sendMessage(menu);
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/QuickSellMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/QuickSellMenu.java
@@ -1,0 +1,31 @@
+package org.maks.fishingPlugin.gui;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.service.QuickSellService;
+
+public class QuickSellMenu {
+
+  private final QuickSellService quickSellService;
+
+  public QuickSellMenu(QuickSellService quickSellService) {
+    this.quickSellService = quickSellService;
+  }
+
+  public void open(Player player) {
+    Component menu = Component.text()
+        .append(Component.text("Quick Sell").color(NamedTextColor.GREEN))
+        .append(Component.newline())
+        .append(Component.text("[Sell All Fish]").color(NamedTextColor.GOLD)
+            .clickEvent(ClickEvent.callback(audience -> {
+              double amount = quickSellService.sellAll(player);
+              player.sendMessage(Component.text("Sold fish for "
+                  + quickSellService.currencySymbol()
+                  + String.format("%.2f", amount)).color(NamedTextColor.YELLOW));
+            })))
+        .build();
+    player.sendMessage(menu);
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/RodShopMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/RodShopMenu.java
@@ -1,0 +1,13 @@
+package org.maks.fishingPlugin.gui;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+
+public class RodShopMenu {
+
+  public void open(Player player) {
+    player.sendMessage(Component.text("Rod shop is not implemented yet.")
+        .color(NamedTextColor.GRAY));
+  }
+}


### PR DESCRIPTION
## Summary
- replace command subcommands with an Adventure-powered `MainMenu`
- add `QuickSellMenu`, `RodShopMenu`, and `QuestMenu` UI classes
- wire up new menus in `FishingPlugin` and simplify `FishingCommand`

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e26d9fa74832a90b50ab56fe580a0