### PR TITLE
feat: add admin editing menus

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -31,6 +31,8 @@ import org.maks.fishingPlugin.gui.MainMenu;
 import org.maks.fishingPlugin.gui.QuickSellMenu;
 import org.maks.fishingPlugin.gui.RodShopMenu;
 import org.maks.fishingPlugin.gui.QuestMenu;
+import org.maks.fishingPlugin.gui.AdminLootEditorMenu;
+import org.maks.fishingPlugin.gui.AdminQuestEditorMenu;
 import net.milkbowl.vault.economy.Economy;
 
 public final class FishingPlugin extends JavaPlugin {
@@ -97,6 +99,17 @@ public final class FishingPlugin extends JavaPlugin {
                 }
             }
         }
+        for (Category cat : Category.values()) {
+            String mKey = "scale_mode_" + cat.name();
+            if (params.containsKey(mKey)) {
+                try {
+                    ScaleMode mode = ScaleMode.valueOf(params.get(mKey));
+                    double a = Double.parseDouble(params.getOrDefault("scale_a_" + cat.name(), "0"));
+                    double k = Double.parseDouble(params.getOrDefault("scale_k_" + cat.name(), "0"));
+                    scaling.put(cat, new ScaleConf(mode, a, k));
+                } catch (IllegalArgumentException ignored) {}
+            }
+        }
         this.lootService = new LootService(scaling);
         try {
             for (LootEntry entry : lootRepo.findAll()) {
@@ -136,8 +149,10 @@ public final class FishingPlugin extends JavaPlugin {
         QuickSellMenu quickSellMenu = new QuickSellMenu(quickSellService);
         RodShopMenu rodShopMenu = new RodShopMenu();
         QuestMenu questMenu = new QuestMenu(questService);
+        AdminQuestEditorMenu adminQuestMenu = new AdminQuestEditorMenu(questService, questRepo);
+        AdminLootEditorMenu adminMenu = new AdminLootEditorMenu(lootService, lootRepo, paramRepo, adminQuestMenu);
         MainMenu mainMenu = new MainMenu(quickSellMenu, rodShopMenu, questMenu);
-        getCommand("fishing").setExecutor(new FishingCommand(mainMenu, requiredPlayerLevel));
+        getCommand("fishing").setExecutor(new FishingCommand(mainMenu, adminMenu, requiredPlayerLevel));
 
         getLogger().info("FishingPlugin enabled");
     }

--- a/src/main/java/org/maks/fishingPlugin/command/FishingCommand.java
+++ b/src/main/java/org/maks/fishingPlugin/command/FishingCommand.java
@@ -5,6 +5,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.maks.fishingPlugin.gui.MainMenu;
+import org.maks.fishingPlugin.gui.AdminLootEditorMenu;
 
 /**
  * Command that opens the main fishing menu.
@@ -12,10 +13,12 @@ import org.maks.fishingPlugin.gui.MainMenu;
 public class FishingCommand implements CommandExecutor {
 
   private final MainMenu mainMenu;
+  private final AdminLootEditorMenu adminMenu;
   private final int requiredLevel;
 
-  public FishingCommand(MainMenu mainMenu, int requiredLevel) {
+  public FishingCommand(MainMenu mainMenu, AdminLootEditorMenu adminMenu, int requiredLevel) {
     this.mainMenu = mainMenu;
+    this.adminMenu = adminMenu;
     this.requiredLevel = requiredLevel;
   }
 
@@ -23,6 +26,14 @@ public class FishingCommand implements CommandExecutor {
   public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
     if (!(sender instanceof Player player)) {
       sender.sendMessage("Only players can use this command.");
+      return true;
+    }
+    if (args.length > 0 && args[0].equalsIgnoreCase("admin")) {
+      if (!player.hasPermission("fishing.admin")) {
+        player.sendMessage("You don't have permission.");
+        return true;
+      }
+      adminMenu.open(player);
       return true;
     }
     if (player.getLevel() < requiredLevel) {

--- a/src/main/java/org/maks/fishingPlugin/data/LootRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/LootRepo.java
@@ -44,5 +44,26 @@ public class LootRepo {
       return list;
     }
   }
+
+  /** Insert or update a loot entry. */
+  public void upsert(LootEntry entry) throws SQLException {
+    String sql =
+        "MERGE INTO loot KEY(key) VALUES (?,?,?,?,?,?,?,?,?,?,?)";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, entry.key());
+      ps.setString(2, entry.category().name());
+      ps.setDouble(3, entry.baseWeight());
+      ps.setInt(4, entry.minRodLevel());
+      ps.setBoolean(5, entry.broadcast());
+      ps.setDouble(6, entry.priceBase());
+      ps.setDouble(7, entry.pricePerKg());
+      ps.setDouble(8, entry.payoutMultiplier());
+      ps.setDouble(9, entry.minWeightG());
+      ps.setDouble(10, entry.maxWeightG());
+      ps.setString(11, entry.itemBase64());
+      ps.executeUpdate();
+    }
+  }
 }
 

--- a/src/main/java/org/maks/fishingPlugin/data/ParamRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/ParamRepo.java
@@ -29,5 +29,16 @@ public class ParamRepo {
     }
     return map;
   }
+
+  /** Insert or update a parameter. */
+  public void set(String key, String value) throws SQLException {
+    String sql = "MERGE INTO param KEY(key) VALUES (?, ?)";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, key);
+      ps.setString(2, value);
+      ps.executeUpdate();
+    }
+  }
 }
 

--- a/src/main/java/org/maks/fishingPlugin/data/QuestRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/QuestRepo.java
@@ -30,5 +30,17 @@ public class QuestRepo {
       return list;
     }
   }
+
+  /** Insert or update quest stage. */
+  public void upsert(QuestStage stage) throws SQLException {
+    String sql = "MERGE INTO quest KEY(stage) VALUES (?,?,?)";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setInt(1, stage.stage());
+      ps.setInt(2, stage.goal());
+      ps.setDouble(3, stage.reward());
+      ps.executeUpdate();
+    }
+  }
 }
 

--- a/src/main/java/org/maks/fishingPlugin/gui/AdminLootEditorMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/AdminLootEditorMenu.java
@@ -1,0 +1,160 @@
+package org.maks.fishingPlugin.gui;
+
+import java.sql.SQLException;
+import java.util.UUID;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.maks.fishingPlugin.data.LootRepo;
+import org.maks.fishingPlugin.data.ParamRepo;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.LootEntry;
+import org.maks.fishingPlugin.model.ScaleConf;
+import org.maks.fishingPlugin.model.ScaleMode;
+import org.maks.fishingPlugin.service.LootService;
+import org.maks.fishingPlugin.util.ItemSerialization;
+
+/** Chat-based admin editor for loot and scaling. */
+public class AdminLootEditorMenu {
+
+  private final LootService lootService;
+  private final LootRepo lootRepo;
+  private final ParamRepo paramRepo;
+  private final AdminQuestEditorMenu questMenu;
+
+  public AdminLootEditorMenu(LootService lootService, LootRepo lootRepo, ParamRepo paramRepo,
+      AdminQuestEditorMenu questMenu) {
+    this.lootService = lootService;
+    this.lootRepo = lootRepo;
+    this.paramRepo = paramRepo;
+    this.questMenu = questMenu;
+  }
+
+  public void open(Player player) {
+    Component menu = Component.text()
+        .append(Component.text("Admin Editor").color(NamedTextColor.RED))
+        .append(Component.newline())
+        .append(Component.text("[Add From Hand]").color(NamedTextColor.GREEN)
+            .clickEvent(ClickEvent.callback(a -> addFromHand(player))))
+        .append(Component.newline())
+        .append(Component.text("[Edit Weights]").color(NamedTextColor.YELLOW)
+            .clickEvent(ClickEvent.callback(a -> openWeights(player))))
+        .append(Component.newline())
+        .append(Component.text("[Edit Scaling]").color(NamedTextColor.AQUA)
+            .clickEvent(ClickEvent.callback(a -> openScaling(player))))
+        .append(Component.newline())
+        .append(Component.text("[Edit Quests]").color(NamedTextColor.GOLD)
+            .clickEvent(ClickEvent.callback(a -> questMenu.open(player))))
+        .build();
+    player.sendMessage(menu);
+  }
+
+  private void addFromHand(Player player) {
+    ItemStack item = player.getInventory().getItemInMainHand();
+    if (item == null || item.getType().isAir()) {
+      player.sendMessage("Hold an item in your hand.");
+      return;
+    }
+    String key = "hand_" + UUID.randomUUID();
+    LootEntry entry = new LootEntry(key, Category.COMMON, 1.0, 0, false, 0.0,
+        0.0, 1.0, 100.0, 200.0, ItemSerialization.toBase64(item));
+    lootService.addEntry(entry);
+    try {
+      lootRepo.upsert(entry);
+    } catch (SQLException e) {
+      player.sendMessage("DB error: " + e.getMessage());
+    }
+    player.sendMessage("Added loot entry " + key);
+  }
+
+  private void openWeights(Player player) {
+    Component menu = Component.text("Weights").color(NamedTextColor.YELLOW);
+    for (LootEntry e : lootService.getEntries()) {
+      Component line = Component.text()
+          .append(Component.newline())
+          .append(Component.text(e.key() + " = " + String.format("%.2f", e.baseWeight())))
+          .append(Component.text(" [+]").color(NamedTextColor.GREEN)
+              .clickEvent(ClickEvent.callback(a -> adjustWeight(player, e, 1.0))))
+          .append(Component.text(" [-]").color(NamedTextColor.RED)
+              .clickEvent(ClickEvent.callback(a -> adjustWeight(player, e, -1.0))))
+          .build();
+      menu = menu.append(line);
+    }
+    menu = menu.append(Component.newline()).append(Component.text("[Back]").color(NamedTextColor.GRAY)
+        .clickEvent(ClickEvent.callback(a -> open(player))));
+    player.sendMessage(menu);
+  }
+
+  private void adjustWeight(Player player, LootEntry e, double delta) {
+    double newWeight = Math.max(0.0, e.baseWeight() + delta);
+    LootEntry updated = new LootEntry(e.key(), e.category(), newWeight, e.minRodLevel(), e.broadcast(),
+        e.priceBase(), e.pricePerKg(), e.payoutMultiplier(), e.minWeightG(), e.maxWeightG(), e.itemBase64());
+    lootService.updateEntry(updated);
+    try {
+      lootRepo.upsert(updated);
+    } catch (SQLException ex) {
+      player.sendMessage("DB error: " + ex.getMessage());
+    }
+    openWeights(player);
+  }
+
+  private void openScaling(Player player) {
+    Component menu = Component.text("Scaling").color(NamedTextColor.AQUA);
+    for (Category cat : Category.values()) {
+      ScaleConf conf = lootService.getScale(cat);
+      if (conf == null) {
+        conf = new ScaleConf(ScaleMode.EXP, 0, 0);
+      }
+      Component line = Component.text()
+          .append(Component.newline())
+          .append(Component.text(cat.name() + " " + conf.mode() + " a=" + conf.a() + " k=" + conf.k()))
+          .append(Component.text(" [Mode]").color(NamedTextColor.YELLOW)
+              .clickEvent(ClickEvent.callback(a -> cycleMode(player, cat, conf))))
+          .append(Component.text(" [A+]").color(NamedTextColor.GREEN)
+              .clickEvent(ClickEvent.callback(a -> adjustA(player, cat, conf, 0.1))))
+          .append(Component.text(" [A-]").color(NamedTextColor.RED)
+              .clickEvent(ClickEvent.callback(a -> adjustA(player, cat, conf, -0.1))))
+          .append(Component.text(" [K+]").color(NamedTextColor.GREEN)
+              .clickEvent(ClickEvent.callback(a -> adjustK(player, cat, conf, 0.1))))
+          .append(Component.text(" [K-]").color(NamedTextColor.RED)
+              .clickEvent(ClickEvent.callback(a -> adjustK(player, cat, conf, -0.1))))
+          .build();
+      menu = menu.append(line);
+    }
+    menu = menu.append(Component.newline()).append(Component.text("[Back]").color(NamedTextColor.GRAY)
+        .clickEvent(ClickEvent.callback(a -> open(player))));
+    player.sendMessage(menu);
+  }
+
+  private void cycleMode(Player player, Category cat, ScaleConf conf) {
+    ScaleMode mode = conf.mode() == ScaleMode.EXP ? ScaleMode.POLY : ScaleMode.EXP;
+    ScaleConf updated = new ScaleConf(mode, conf.a(), conf.k());
+    saveScale(cat, updated, player);
+    openScaling(player);
+  }
+
+  private void adjustA(Player player, Category cat, ScaleConf conf, double delta) {
+    ScaleConf updated = new ScaleConf(conf.mode(), conf.a() + delta, conf.k());
+    saveScale(cat, updated, player);
+    openScaling(player);
+  }
+
+  private void adjustK(Player player, Category cat, ScaleConf conf, double delta) {
+    ScaleConf updated = new ScaleConf(conf.mode(), conf.a(), conf.k() + delta);
+    saveScale(cat, updated, player);
+    openScaling(player);
+  }
+
+  private void saveScale(Category cat, ScaleConf conf, Player player) {
+    lootService.setScale(cat, conf);
+    try {
+      paramRepo.set("scale_mode_" + cat.name(), conf.mode().name());
+      paramRepo.set("scale_a_" + cat.name(), String.valueOf(conf.a()));
+      paramRepo.set("scale_k_" + cat.name(), String.valueOf(conf.k()));
+    } catch (SQLException e) {
+      player.sendMessage("DB error: " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/AdminQuestEditorMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/AdminQuestEditorMenu.java
@@ -1,0 +1,51 @@
+package org.maks.fishingPlugin.gui;
+
+import java.sql.SQLException;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.data.QuestRepo;
+import org.maks.fishingPlugin.model.QuestStage;
+import org.maks.fishingPlugin.service.QuestChainService;
+
+/** Simple chat-based quest reward editor. */
+public class AdminQuestEditorMenu {
+
+  private final QuestChainService questService;
+  private final QuestRepo questRepo;
+
+  public AdminQuestEditorMenu(QuestChainService questService, QuestRepo questRepo) {
+    this.questService = questService;
+    this.questRepo = questRepo;
+  }
+
+  public void open(Player player) {
+    Component menu = Component.text("Quest Editor").color(NamedTextColor.GOLD);
+    for (QuestStage stage : questService.getStages()) {
+      Component line = Component.text()
+          .append(Component.newline())
+          .append(Component.text("Stage " + stage.stage() + " reward: " +
+              String.format("%.0f", stage.reward())))
+          .append(Component.text(" [+]").color(NamedTextColor.GREEN)
+              .clickEvent(ClickEvent.callback(a -> adjust(stage, 10.0, player))))
+          .append(Component.text(" [-]").color(NamedTextColor.RED)
+              .clickEvent(ClickEvent.callback(a -> adjust(stage, -10.0, player))))
+          .build();
+      menu = menu.append(line);
+    }
+    player.sendMessage(menu);
+  }
+
+  private void adjust(QuestStage stage, double delta, Player player) {
+    double newReward = Math.max(0, stage.reward() + delta);
+    QuestStage updated = new QuestStage(stage.stage(), stage.goal(), newReward);
+    questService.updateStage(updated);
+    try {
+      questRepo.upsert(updated);
+    } catch (SQLException e) {
+      player.sendMessage("DB error: " + e.getMessage());
+    }
+    open(player);
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/LootService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LootService.java
@@ -31,6 +31,31 @@ public class LootService {
     byKey.put(entry.key(), entry);
   }
 
+  /** Replace existing entry by key. */
+  public void updateEntry(LootEntry entry) {
+    for (int i = 0; i < entries.size(); i++) {
+      if (entries.get(i).key().equals(entry.key())) {
+        entries.set(i, entry);
+        byKey.put(entry.key(), entry);
+        return;
+      }
+    }
+    addEntry(entry);
+  }
+
+  /** Expose registered entries. */
+  public List<LootEntry> getEntries() {
+    return List.copyOf(entries);
+  }
+
+  public ScaleConf getScale(Category cat) {
+    return scaling.get(cat);
+  }
+
+  public void setScale(Category cat, ScaleConf conf) {
+    scaling.put(cat, conf);
+  }
+
   /**
    * Rolls a random loot entry based on rod level.
    */

--- a/src/main/java/org/maks/fishingPlugin/service/QuestChainService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QuestChainService.java
@@ -28,6 +28,21 @@ public class QuestChainService {
     this.stages.addAll(stages);
   }
 
+  public List<QuestStage> getStages() {
+    return List.copyOf(stages);
+  }
+
+  public void updateStage(QuestStage stage) {
+    for (int i = 0; i < stages.size(); i++) {
+      if (stages.get(i).stage() == stage.stage()) {
+        stages.set(i, stage);
+        return;
+      }
+    }
+    stages.add(stage);
+    stages.sort(java.util.Comparator.comparingInt(QuestStage::stage));
+  }
+
   /** Call when a player catches a fish. */
   public void onCatch(Player player) {
     Progress p = progress.computeIfAbsent(player.getUniqueId(), u -> new Progress());

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,5 +5,9 @@ api-version: 1.20
 commands:
   fishing:
     description: Fishing commands
-    usage: /fishing sell|warp <key>|quest
+    usage: /fishing
     permission: fishing.use
+permissions:
+  fishing.admin:
+    description: Allows editing loot and quests
+    default: op


### PR DESCRIPTION
## Summary
- add chat-based admin loot and quest editors
- allow editing quest rewards and loot scaling with DB persistence
- expose /fishing admin command requiring `fishing.admin`

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_689e28bcfc74832aac4ddbc804f97523