### PR TITLE
feat: persistent quest chain with rewards

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -14,6 +14,7 @@ import org.maks.fishingPlugin.data.LootRepo;
 import org.maks.fishingPlugin.data.ParamRepo;
 import org.maks.fishingPlugin.data.ProfileRepo;
 import org.maks.fishingPlugin.data.QuestRepo;
+import org.maks.fishingPlugin.data.QuestProgressRepo;
 import org.maks.fishingPlugin.listener.FishingListener;
 import org.maks.fishingPlugin.listener.QteListener;
 import org.maks.fishingPlugin.model.Category;
@@ -49,6 +50,7 @@ public final class FishingPlugin extends JavaPlugin {
     private Database database;
     private LootRepo lootRepo;
     private QuestRepo questRepo;
+    private QuestProgressRepo questProgressRepo;
     private ParamRepo paramRepo;
     private ProfileRepo profileRepo;
 
@@ -62,6 +64,7 @@ public final class FishingPlugin extends JavaPlugin {
         Flyway.configure().dataSource(ds).load().migrate();
         this.lootRepo = new LootRepo(ds);
         this.questRepo = new QuestRepo(ds);
+        this.questProgressRepo = new QuestProgressRepo(ds);
         this.paramRepo = new ParamRepo(ds);
         this.profileRepo = new ProfileRepo(ds);
 
@@ -135,12 +138,7 @@ public final class FishingPlugin extends JavaPlugin {
         this.quickSellService = new QuickSellService(this, lootService, economy, multiplier, tax, symbol);
         this.antiCheatService = new AntiCheatService();
         this.qteService = new QteService(antiCheatService);
-        this.questService = new QuestChainService(economy);
-        try {
-            questService.setStages(questRepo.findAll());
-        } catch (SQLException e) {
-            getLogger().warning("Failed to load quest stages: " + e.getMessage());
-        }
+        this.questService = new QuestChainService(economy, questRepo, questProgressRepo, this);
 
         Bukkit.getPluginManager().registerEvents(
             new FishingListener(lootService, awarder, levelService, qteService, questService, requiredPlayerLevel), this);

--- a/src/main/java/org/maks/fishingPlugin/data/QuestProgressRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/QuestProgressRepo.java
@@ -1,0 +1,48 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.maks.fishingPlugin.model.QuestProgress;
+
+/** Repository for quest progress. */
+public class QuestProgressRepo {
+
+  private final DataSource dataSource;
+
+  public QuestProgressRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public Optional<QuestProgress> find(UUID uuid) throws SQLException {
+    String sql = "SELECT player_uuid, stage, count FROM quests_chain_progress WHERE player_uuid=?";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, uuid.toString());
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          return Optional.of(
+              new QuestProgress(UUID.fromString(rs.getString(1)), rs.getInt(2), rs.getInt(3)));
+        }
+        return Optional.empty();
+      }
+    }
+  }
+
+  /** Insert or update player quest progress. */
+  public void upsert(QuestProgress progress) throws SQLException {
+    String sql =
+        "MERGE INTO quests_chain_progress(player_uuid, stage, count) KEY(player_uuid) VALUES(?,?,?)";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, progress.playerUuid().toString());
+      ps.setInt(2, progress.stage());
+      ps.setInt(3, progress.count());
+      ps.executeUpdate();
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/QuestMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/QuestMenu.java
@@ -4,8 +4,11 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.model.QuestProgress;
+import org.maks.fishingPlugin.model.QuestStage;
 import org.maks.fishingPlugin.service.QuestChainService;
 
+/** Simple text-based quest menu. */
 public class QuestMenu {
 
   private final QuestChainService questService;
@@ -15,12 +18,25 @@ public class QuestMenu {
   }
 
   public void open(Player player) {
-    Component menu = Component.text()
-        .append(Component.text("Quests").color(NamedTextColor.GOLD))
+    if (questService.isCompleted(player)) {
+      player.sendMessage(Component.text("All quests completed.").color(NamedTextColor.GOLD));
+      return;
+    }
+    QuestProgress p = questService.getProgress(player);
+    QuestStage stage = questService.getCurrentStage(p.stage());
+    Component.Builder menu = Component.text()
+        .append(Component.text("Quest Stage " + stage.stage()).color(NamedTextColor.GOLD))
         .append(Component.newline())
-        .append(Component.text("[Claim Reward]").color(NamedTextColor.GREEN)
-            .clickEvent(ClickEvent.callback(audience -> questService.claim(player))))
-        .build();
-    player.sendMessage(menu);
+        .append(Component.text("Progress: " + p.count() + "/" + stage.goal()))
+        .append(Component.newline())
+        .append(Component.text("Reward: $" + String.format("%.0f", stage.reward())))
+        .append(Component.newline());
+    if (p.count() >= stage.goal()) {
+      menu.append(Component.text("[Claim Reward]").color(NamedTextColor.GREEN)
+          .clickEvent(ClickEvent.callback(a -> questService.claim(player))));
+    } else {
+      menu.append(Component.text("Keep fishing...").color(NamedTextColor.GRAY));
+    }
+    player.sendMessage(menu.build());
   }
 }

--- a/src/main/java/org/maks/fishingPlugin/model/QuestProgress.java
+++ b/src/main/java/org/maks/fishingPlugin/model/QuestProgress.java
@@ -1,0 +1,6 @@
+package org.maks.fishingPlugin.model;
+
+import java.util.UUID;
+
+/** Player's quest chain progress. */
+public record QuestProgress(UUID playerUuid, int stage, int count) {}

--- a/src/main/java/org/maks/fishingPlugin/service/QuestChainService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QuestChainService.java
@@ -1,85 +1,175 @@
 package org.maks.fishingPlugin.service;
 
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Logger;
 import net.milkbowl.vault.economy.Economy;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.fishingPlugin.data.QuestProgressRepo;
+import org.maks.fishingPlugin.data.QuestRepo;
+import org.maks.fishingPlugin.model.QuestProgress;
 import org.maks.fishingPlugin.model.QuestStage;
 
 /**
- * Minimal quest chain service with catch-count goals and money rewards.
+ * Quest chain service with persistent progress and definitions loaded from DB or YAML.
  */
 public class QuestChainService {
 
   private final Economy economy;
+  private final QuestRepo questRepo;
+  private final QuestProgressRepo progressRepo;
+  private final Logger logger;
   private final List<QuestStage> stages = new ArrayList<>();
-  private final Map<UUID, Progress> progress = new HashMap<>();
+  private final Map<UUID, QuestProgress> progress = new HashMap<>();
 
-  public QuestChainService(Economy economy) {
+  public QuestChainService(Economy economy, QuestRepo questRepo,
+      QuestProgressRepo progressRepo, JavaPlugin plugin) {
     this.economy = economy;
+    this.questRepo = questRepo;
+    this.progressRepo = progressRepo;
+    this.logger = plugin.getLogger();
+    loadDefinitions(plugin);
   }
 
-  /** Replace quest stages with definitions from storage. */
-  public void setStages(List<QuestStage> stages) {
-    this.stages.clear();
-    this.stages.addAll(stages);
+  private void loadDefinitions(JavaPlugin plugin) {
+    try {
+      List<QuestStage> fromDb = questRepo.findAll();
+      if (fromDb.size() == 21) {
+        stages.addAll(fromDb);
+        return;
+      }
+    } catch (SQLException e) {
+      logger.warning("Failed to load quest stages from DB: " + e.getMessage());
+    }
+    try (InputStream is = plugin.getResource("quests.yml")) {
+      if (is == null) {
+        logger.warning("quests.yml not found");
+        return;
+      }
+      YamlConfiguration cfg = YamlConfiguration.loadConfiguration(new InputStreamReader(is));
+      var list = cfg.getMapList("quests");
+      for (Map<?, ?> map : list) {
+        int stage = ((Number) map.get("stage")).intValue();
+        int goal = ((Number) map.get("goal")).intValue();
+        double reward = ((Number) map.get("reward")).doubleValue();
+        QuestStage qs = new QuestStage(stage, goal, reward);
+        stages.add(qs);
+        try {
+          questRepo.upsert(qs);
+        } catch (SQLException e) {
+          logger.warning("Failed to persist quest stage " + stage + ": " + e.getMessage());
+        }
+      }
+      stages.sort(Comparator.comparingInt(QuestStage::stage));
+    } catch (Exception e) {
+      logger.warning("Failed to load quest stages from YAML: " + e.getMessage());
+    }
   }
 
   public List<QuestStage> getStages() {
     return List.copyOf(stages);
   }
 
+  /** Insert or update a quest stage definition. */
   public void updateStage(QuestStage stage) {
+    boolean replaced = false;
     for (int i = 0; i < stages.size(); i++) {
       if (stages.get(i).stage() == stage.stage()) {
         stages.set(i, stage);
-        return;
+        replaced = true;
+        break;
       }
     }
-    stages.add(stage);
-    stages.sort(java.util.Comparator.comparingInt(QuestStage::stage));
+    if (!replaced) {
+      stages.add(stage);
+    }
+    stages.sort(Comparator.comparingInt(QuestStage::stage));
+    try {
+      questRepo.upsert(stage);
+    } catch (SQLException e) {
+      logger.warning("Failed to persist quest stage " + stage.stage() + ": " + e.getMessage());
+    }
+  }
+
+  private QuestProgress loadProgress(UUID uuid) {
+    return progress.computeIfAbsent(uuid, u -> {
+      try {
+        return progressRepo.find(u).orElse(new QuestProgress(u, 0, 0));
+      } catch (SQLException e) {
+        logger.warning("Failed to load quest progress: " + e.getMessage());
+        return new QuestProgress(u, 0, 0);
+      }
+    });
+  }
+
+  private void saveProgress(QuestProgress progress) {
+    try {
+      progressRepo.upsert(progress);
+    } catch (SQLException e) {
+      logger.warning("Failed to save quest progress: " + e.getMessage());
+    }
   }
 
   /** Call when a player catches a fish. */
   public void onCatch(Player player) {
-    Progress p = progress.computeIfAbsent(player.getUniqueId(), u -> new Progress());
-    if (p.stage >= stages.size()) {
+    QuestProgress p = loadProgress(player.getUniqueId());
+    if (p.stage() >= stages.size()) {
       return; // all done
     }
-    p.count++;
-    QuestStage stage = stages.get(p.stage);
-    if (p.count >= stage.goal()) {
+    p = new QuestProgress(p.playerUuid(), p.stage(), p.count() + 1);
+    progress.put(player.getUniqueId(), p);
+    saveProgress(p);
+    QuestStage stage = stages.get(p.stage());
+    if (p.count() >= stage.goal()) {
       player.sendMessage(
-          "Quest stage " + stage.stage() + " complete! Use /fishing quest to claim reward.");
+          "Quest stage " + stage.stage() + " complete! Open the quest menu to claim reward.");
     }
+  }
+
+  public QuestProgress getProgress(Player player) {
+    return loadProgress(player.getUniqueId());
+  }
+
+  public QuestStage getCurrentStage(int index) {
+    if (index < 0 || index >= stages.size()) {
+      return null;
+    }
+    return stages.get(index);
   }
 
   /** Claim reward or show progress if not finished. */
   public void claim(Player player) {
-    Progress p = progress.computeIfAbsent(player.getUniqueId(), u -> new Progress());
-    if (p.stage >= stages.size()) {
+    QuestProgress p = loadProgress(player.getUniqueId());
+    if (p.stage() >= stages.size()) {
       player.sendMessage("All quests completed.");
       return;
     }
-    QuestStage stage = stages.get(p.stage);
-    if (p.count < stage.goal()) {
+    QuestStage stage = stages.get(p.stage());
+    if (p.count() < stage.goal()) {
       player.sendMessage(
-          "Catch " + (stage.goal() - p.count) + " more fish to finish quest stage " + stage.stage());
+          "Catch " + (stage.goal() - p.count()) + " more fish to finish quest stage "
+              + stage.stage());
       return;
     }
     economy.depositPlayer(player, stage.reward());
     player.sendMessage(
-        "Received $" + String.format("%.0f", stage.reward()) +
-            " for completing quest stage " + stage.stage());
-    p.stage++;
-    p.count = 0;
+        "Received $" + String.format("%.0f", stage.reward())
+            + " for completing quest stage " + stage.stage());
+    p = new QuestProgress(p.playerUuid(), p.stage() + 1, 0);
+    progress.put(player.getUniqueId(), p);
+    saveProgress(p);
   }
 
-  private static class Progress {
-    int stage = 0;
-    int count = 0;
+  public boolean isCompleted(Player player) {
+    return loadProgress(player.getUniqueId()).stage() >= stages.size();
   }
 }

--- a/src/main/resources/db/migration/V2__add_quest_chain_progress.sql
+++ b/src/main/resources/db/migration/V2__add_quest_chain_progress.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS quests_chain_progress (
+    player_uuid VARCHAR(36) PRIMARY KEY,
+    stage INT NOT NULL,
+    count INT NOT NULL
+);

--- a/src/main/resources/quests.yml
+++ b/src/main/resources/quests.yml
@@ -1,0 +1,64 @@
+quests:
+  - stage: 1
+    goal: 10
+    reward: 100
+  - stage: 2
+    goal: 20
+    reward: 200
+  - stage: 3
+    goal: 30
+    reward: 300
+  - stage: 4
+    goal: 40
+    reward: 400
+  - stage: 5
+    goal: 50
+    reward: 500
+  - stage: 6
+    goal: 60
+    reward: 600
+  - stage: 7
+    goal: 70
+    reward: 700
+  - stage: 8
+    goal: 80
+    reward: 800
+  - stage: 9
+    goal: 90
+    reward: 900
+  - stage: 10
+    goal: 100
+    reward: 1000
+  - stage: 11
+    goal: 110
+    reward: 1100
+  - stage: 12
+    goal: 120
+    reward: 1200
+  - stage: 13
+    goal: 130
+    reward: 1300
+  - stage: 14
+    goal: 140
+    reward: 1400
+  - stage: 15
+    goal: 150
+    reward: 1500
+  - stage: 16
+    goal: 160
+    reward: 1600
+  - stage: 17
+    goal: 170
+    reward: 1700
+  - stage: 18
+    goal: 180
+    reward: 1800
+  - stage: 19
+    goal: 190
+    reward: 1900
+  - stage: 20
+    goal: 200
+    reward: 2000
+  - stage: 21
+    goal: 210
+    reward: 2100


### PR DESCRIPTION
## Summary
- load quest stages from database or bundled YAML
- persist player quest progress and claim rewards via GUI
- introduce quests_chain_progress table

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e2c7e3d6c832a95a95871278e80dd