### PR TITLE
Add fish quality and quick sell summary

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/data/LootRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/LootRepo.java
@@ -21,7 +21,8 @@ public class LootRepo {
 
   public List<LootEntry> findAll() throws SQLException {
     String sql = "SELECT key, category, base_weight, min_rod_level, broadcast, " +
-        "price_base, price_per_kg, payout_multiplier, min_weight_g, max_weight_g, item_base64 FROM loot";
+        "price_base, price_per_kg, payout_multiplier, quality_s_weight, quality_a_weight, " +
+        "quality_b_weight, quality_c_weight, min_weight_g, max_weight_g, item_base64 FROM loot";
     try (Connection con = dataSource.getConnection();
          PreparedStatement ps = con.prepareStatement(sql);
          ResultSet rs = ps.executeQuery()) {
@@ -38,7 +39,11 @@ public class LootRepo {
             rs.getDouble(8),
             rs.getDouble(9),
             rs.getDouble(10),
-            rs.getString(11)
+            rs.getDouble(11),
+            rs.getDouble(12),
+            rs.getDouble(13),
+            rs.getDouble(14),
+            rs.getString(15)
         ));
       }
       return list;
@@ -48,7 +53,7 @@ public class LootRepo {
   /** Insert or update a loot entry. */
   public void upsert(LootEntry entry) throws SQLException {
     String sql =
-        "MERGE INTO loot KEY(key) VALUES (?,?,?,?,?,?,?,?,?,?,?)";
+        "MERGE INTO loot KEY(key) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
     try (Connection con = dataSource.getConnection();
          PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, entry.key());
@@ -59,9 +64,13 @@ public class LootRepo {
       ps.setDouble(6, entry.priceBase());
       ps.setDouble(7, entry.pricePerKg());
       ps.setDouble(8, entry.payoutMultiplier());
-      ps.setDouble(9, entry.minWeightG());
-      ps.setDouble(10, entry.maxWeightG());
-      ps.setString(11, entry.itemBase64());
+      ps.setDouble(9, entry.qualitySWeight());
+      ps.setDouble(10, entry.qualityAWeight());
+      ps.setDouble(11, entry.qualityBWeight());
+      ps.setDouble(12, entry.qualityCWeight());
+      ps.setDouble(13, entry.minWeightG());
+      ps.setDouble(14, entry.maxWeightG());
+      ps.setString(15, entry.itemBase64());
       ps.executeUpdate();
     }
   }

--- a/src/main/java/org/maks/fishingPlugin/gui/AdminLootEditorMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/AdminLootEditorMenu.java
@@ -59,7 +59,7 @@ public class AdminLootEditorMenu {
     }
     String key = "hand_" + UUID.randomUUID();
     LootEntry entry = new LootEntry(key, Category.COMMON, 1.0, 0, false, 0.0,
-        0.0, 1.0, 100.0, 200.0, ItemSerialization.toBase64(item));
+        0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 100.0, 200.0, ItemSerialization.toBase64(item));
     lootService.addEntry(entry);
     try {
       lootRepo.upsert(entry);
@@ -90,7 +90,7 @@ public class AdminLootEditorMenu {
   private void adjustWeight(Player player, LootEntry e, double delta) {
     double newWeight = Math.max(0.0, e.baseWeight() + delta);
     LootEntry updated = new LootEntry(e.key(), e.category(), newWeight, e.minRodLevel(), e.broadcast(),
-        e.priceBase(), e.pricePerKg(), e.payoutMultiplier(), e.minWeightG(), e.maxWeightG(), e.itemBase64());
+        e.priceBase(), e.pricePerKg(), e.payoutMultiplier(), e.qualitySWeight(), e.qualityAWeight(), e.qualityBWeight(), e.qualityCWeight(), e.minWeightG(), e.maxWeightG(), e.itemBase64());
     lootService.updateEntry(updated);
     try {
       lootRepo.upsert(updated);

--- a/src/main/java/org/maks/fishingPlugin/gui/QuickSellMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/QuickSellMenu.java
@@ -1,31 +1,76 @@
 package org.maks.fishingPlugin.gui;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.model.SellSummary;
 import org.maks.fishingPlugin.service.QuickSellService;
 
 public class QuickSellMenu {
 
   private final QuickSellService quickSellService;
+  private final Map<java.util.UUID, Set<String>> selections = new HashMap<>();
 
   public QuickSellMenu(QuickSellService quickSellService) {
     this.quickSellService = quickSellService;
   }
 
   public void open(Player player) {
+    SellSummary summary = quickSellService.summarize(player);
+    Set<String> sel = selections.computeIfAbsent(player.getUniqueId(), k -> new HashSet<>());
     Component menu = Component.text()
         .append(Component.text("Quick Sell").color(NamedTextColor.GREEN))
+        .append(Component.newline());
+
+    for (SellSummary.Entry e : summary.entries()) {
+      String gk = QuickSellService.groupKey(e.key(), e.quality());
+      boolean selected = sel.contains(gk);
+      Component line = Component.text(e.key() + " [" + e.quality() + "] x" + e.amount() + " = "
+          + quickSellService.currencySymbol() + String.format("%.2f", e.price()))
+          .color(selected ? NamedTextColor.GREEN : NamedTextColor.WHITE)
+          .append(Component.text(selected ? " [Unselect]" : " [Select]")
+              .color(NamedTextColor.AQUA)
+              .clickEvent(ClickEvent.callback(a -> {
+                if (selected) {
+                  sel.remove(gk);
+                } else {
+                  sel.add(gk);
+                }
+                open(player);
+              })));
+      menu = menu.append(line).append(Component.newline());
+    }
+
+    menu = menu
+        .append(Component.text("Total: " + quickSellService.currencySymbol()
+            + String.format("%.2f", summary.totalPrice())).color(NamedTextColor.YELLOW))
         .append(Component.newline())
-        .append(Component.text("[Sell All Fish]").color(NamedTextColor.GOLD)
-            .clickEvent(ClickEvent.callback(audience -> {
+        .append(Component.text("[Sell Selected]").color(NamedTextColor.GOLD)
+            .clickEvent(ClickEvent.callback(a -> {
+              double amount = quickSellService.sellSelected(player, sel);
+              player.sendMessage(Component.text("Sold fish for "
+                  + quickSellService.currencySymbol() + String.format("%.2f", amount))
+                  .color(NamedTextColor.YELLOW));
+              sel.clear();
+              open(player);
+            })))
+        .append(Component.space())
+        .append(Component.text("[Sell All]").color(NamedTextColor.RED)
+            .clickEvent(ClickEvent.callback(a -> {
               double amount = quickSellService.sellAll(player);
               player.sendMessage(Component.text("Sold fish for "
-                  + quickSellService.currencySymbol()
-                  + String.format("%.2f", amount)).color(NamedTextColor.YELLOW));
+                  + quickSellService.currencySymbol() + String.format("%.2f", amount))
+                  .color(NamedTextColor.YELLOW));
+              sel.clear();
+              open(player);
             })))
         .build();
+
     player.sendMessage(menu);
   }
 }

--- a/src/main/java/org/maks/fishingPlugin/model/LootEntry.java
+++ b/src/main/java/org/maks/fishingPlugin/model/LootEntry.java
@@ -13,6 +13,10 @@ public record LootEntry(
     double priceBase,
     double pricePerKg,
     double payoutMultiplier,
+    double qualitySWeight,
+    double qualityAWeight,
+    double qualityBWeight,
+    double qualityCWeight,
     double minWeightG,
     double maxWeightG,
     String itemBase64

--- a/src/main/java/org/maks/fishingPlugin/model/Quality.java
+++ b/src/main/java/org/maks/fishingPlugin/model/Quality.java
@@ -1,0 +1,11 @@
+package org.maks.fishingPlugin.model;
+
+/**
+ * Quality grades for caught fish.
+ */
+public enum Quality {
+    S,
+    A,
+    B,
+    C
+}

--- a/src/main/java/org/maks/fishingPlugin/model/SellSummary.java
+++ b/src/main/java/org/maks/fishingPlugin/model/SellSummary.java
@@ -1,0 +1,8 @@
+package org.maks.fishingPlugin.model;
+
+import java.util.List;
+
+/** Summary of potential sale grouped by species and quality. */
+public record SellSummary(List<Entry> entries, double totalPrice) {
+    public record Entry(String key, Quality quality, int amount, double price) {}
+}

--- a/src/main/resources/db/migration/V1__create_tables.sql
+++ b/src/main/resources/db/migration/V1__create_tables.sql
@@ -11,12 +11,16 @@ CREATE TABLE IF NOT EXISTS loot (
     min_rod_level INT NOT NULL,
     broadcast BOOLEAN NOT NULL,
     price_base DOUBLE NOT NULL,
-    price_per_kg DOUBLE NOT NULL,
-    payout_multiplier DOUBLE NOT NULL,
-    min_weight_g DOUBLE NOT NULL,
-    max_weight_g DOUBLE NOT NULL,
-    item_base64 TEXT
-);
+      price_per_kg DOUBLE NOT NULL,
+      payout_multiplier DOUBLE NOT NULL,
+      quality_s_weight DOUBLE NOT NULL,
+      quality_a_weight DOUBLE NOT NULL,
+      quality_b_weight DOUBLE NOT NULL,
+      quality_c_weight DOUBLE NOT NULL,
+      min_weight_g DOUBLE NOT NULL,
+      max_weight_g DOUBLE NOT NULL,
+      item_base64 TEXT
+  );
 
 CREATE TABLE IF NOT EXISTS quest (
     stage INT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Track fish quality (S/A/B/C) in loot entries and item NBT
- Summarize inventory value by species and quality, with selective selling
- Add chat GUI for selling all or selected fish

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e2eb2ebb4832aa78e9642a4cb6fd3