### PR TITLE
Add configurable QTE and advanced anti-cheat checks

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,15 @@
 player_level_requirement: 80
 
+qte:
+  clicks: 1
+  window_ms: 1000
+
+anti_cheat:
+  sample_size: 5
+  tolerance_ms: 30
+  action: CANCEL # or REDUCE
+  drop_multiplier: 0.5
+
 economy:
   currency_symbol: "$"
   quicksell_tax: 0.0


### PR DESCRIPTION
## Summary
- make QTE click count and window duration configurable
- analyze click variance and periodicity to detect macros
- allow configurable macro penalties that cancel bites or reduce drop rate

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e307e20a0832aad539b5a8abc4860