### PR TITLE
Add placeholder API hooks and crate rewards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
             <id>papermc-repo</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>placeholderapi-repo</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
       <dependencies>
@@ -84,6 +88,12 @@
               <groupId>net.kyori</groupId>
               <artifactId>adventure-api</artifactId>
               <version>4.17.0</version>
+          </dependency>
+          <dependency>
+              <groupId>me.clip</groupId>
+              <artifactId>placeholderapi</artifactId>
+              <version>2.11.5</version>
+              <scope>provided</scope>
           </dependency>
       </dependencies>
   </project>

--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -53,11 +53,18 @@ public final class FishingPlugin extends JavaPlugin {
     private QuestProgressRepo questProgressRepo;
     private ParamRepo paramRepo;
     private ProfileRepo profileRepo;
+    private boolean hasEliteLootbox;
+    private boolean hasWorldGuard;
+    private boolean hasCitizens;
 
     @Override
     public void onEnable() {
         this.levelService = new LevelService(this);
         saveDefaultConfig();
+        var pm = getServer().getPluginManager();
+        this.hasEliteLootbox = pm.getPlugin("EliteLootbox") != null;
+        this.hasWorldGuard = pm.getPlugin("WorldGuard") != null;
+        this.hasCitizens = pm.getPlugin("Citizens") != null;
 
         this.database = new Database("jdbc:h2:./data/fishing", "sa", "");
         DataSource ds = database.getDataSource();
@@ -152,6 +159,9 @@ public final class FishingPlugin extends JavaPlugin {
 
         this.qteService = new QteService(antiCheatService, clicks, windowMs, macroAction);
         this.questService = new QuestChainService(economy, questRepo, questProgressRepo, this);
+        if (pm.getPlugin("PlaceholderAPI") != null) {
+            new org.maks.fishingPlugin.integration.FishingExpansion(this).register();
+        }
 
         Bukkit.getPluginManager().registerEvents(
             new FishingListener(lootService, awarder, levelService, qteService, questService, requiredPlayerLevel,
@@ -175,6 +185,22 @@ public final class FishingPlugin extends JavaPlugin {
 
     public LootService getLootService() {
         return lootService;
+    }
+
+    public QuestChainService getQuestService() {
+        return questService;
+    }
+
+    public boolean hasEliteLootbox() {
+        return hasEliteLootbox;
+    }
+
+    public boolean hasWorldGuard() {
+        return hasWorldGuard;
+    }
+
+    public boolean hasCitizens() {
+        return hasCitizens;
     }
 
     @Override

--- a/src/main/java/org/maks/fishingPlugin/integration/FishingExpansion.java
+++ b/src/main/java/org/maks/fishingPlugin/integration/FishingExpansion.java
@@ -1,0 +1,63 @@
+package org.maks.fishingPlugin.integration;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.FishingPlugin;
+import org.maks.fishingPlugin.service.LevelService;
+import org.maks.fishingPlugin.service.QuestChainService;
+
+/**
+ * PlaceholderAPI expansion for fishing stats.
+ */
+public class FishingExpansion extends PlaceholderExpansion {
+
+    private final FishingPlugin plugin;
+
+    public FishingExpansion(FishingPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public boolean canRegister() {
+        return true;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "fishing";
+    }
+
+    @Override
+    public String getAuthor() {
+        return String.join(",", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String params) {
+        if (player == null) {
+            return "";
+        }
+        LevelService level = plugin.getLevelService();
+        QuestChainService quest = plugin.getQuestService();
+        switch (params.toLowerCase()) {
+            case "level":
+                return String.valueOf(level.getLevel(player));
+            case "xp":
+                return String.valueOf(level.getXp(player));
+            case "quest_stage":
+                return String.valueOf(quest.getProgress(player).stage());
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/Awarder.java
+++ b/src/main/java/org/maks/fishingPlugin/service/Awarder.java
@@ -14,6 +14,7 @@ import org.maks.fishingPlugin.model.Category;
 import org.maks.fishingPlugin.model.LootEntry;
 import org.maks.fishingPlugin.util.ItemSerialization;
 import org.maks.fishingPlugin.util.WeightedPicker;
+import org.maks.fishingPlugin.FishingPlugin;
 
 /**
  * Grants rolled loot to the player.
@@ -47,6 +48,18 @@ public class Awarder {
       item = ItemSerialization.fromBase64(loot.itemBase64());
     } else if (loot.category() == Category.FISH || loot.category() == Category.FISH_PREMIUM) {
       item = new ItemStack(Material.COD);
+    } else if (loot.category() == Category.FISHERMAN_CHEST) {
+      if (((FishingPlugin) plugin).hasEliteLootbox()) {
+        String cmd = "lootbox give " + player.getName() + " " + loot.key();
+        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
+      } else {
+        plugin.getLogger().warning("EliteLootbox not found; cannot give crate " + loot.key());
+      }
+      player.sendMessage("You obtained: " + loot.key());
+      if (loot.broadcast()) {
+        Bukkit.broadcastMessage(player.getName() + " obtained " + loot.key() + "!");
+      }
+      return new AwardResult(0, null);
     }
 
     if (item == null) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: FishingPlugin
 main: org.maks.fishingPlugin.FishingPlugin
 version: 0.0.1
 api-version: 1.20
+softdepend: [PlaceholderAPI, EliteLootbox, WorldGuard, Citizens]
 commands:
   fishing:
     description: Fishing commands


### PR DESCRIPTION
## Summary
- detect EliteLootbox, WorldGuard and Citizens plugins during startup
- award Fisherman chests via dispatchCommand
- register fishing placeholders through PlaceholderAPI

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*
- `mvn -q -DskipTests -o package` *(failed: missing dependencies in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_689e31ddd154832ab0fda565a4818815