### PR TITLE
Add teleport option to fishing main menu

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -28,6 +28,7 @@ import org.maks.fishingPlugin.service.LootService;
 import org.maks.fishingPlugin.service.QteService;
 import org.maks.fishingPlugin.service.QuestChainService;
 import org.maks.fishingPlugin.service.QuickSellService;
+import org.maks.fishingPlugin.service.TeleportService;
 import org.maks.fishingPlugin.gui.MainMenu;
 import org.maks.fishingPlugin.gui.QuickSellMenu;
 import org.maks.fishingPlugin.gui.RodShopMenu;
@@ -45,6 +46,7 @@ public final class FishingPlugin extends JavaPlugin {
     private QteService qteService;
     private AntiCheatService antiCheatService;
     private QuestChainService questService;
+    private TeleportService teleportService;
     private Economy economy;
     private int requiredPlayerLevel;
     private Database database;
@@ -158,6 +160,7 @@ public final class FishingPlugin extends JavaPlugin {
         QteService.MacroAction macroAction = QteService.MacroAction.valueOf(actionStr.toUpperCase());
 
         this.qteService = new QteService(antiCheatService, clicks, windowMs, macroAction);
+        this.teleportService = new TeleportService(this);
         this.questService = new QuestChainService(economy, questRepo, questProgressRepo, this);
         if (pm.getPlugin("PlaceholderAPI") != null) {
             new org.maks.fishingPlugin.integration.FishingExpansion(this).register();
@@ -173,7 +176,8 @@ public final class FishingPlugin extends JavaPlugin {
         QuestMenu questMenu = new QuestMenu(questService);
         AdminQuestEditorMenu adminQuestMenu = new AdminQuestEditorMenu(questService, questRepo);
         AdminLootEditorMenu adminMenu = new AdminLootEditorMenu(lootService, lootRepo, paramRepo, adminQuestMenu);
-        MainMenu mainMenu = new MainMenu(quickSellMenu, rodShopMenu, questMenu);
+        MainMenu mainMenu = new MainMenu(quickSellMenu, rodShopMenu, questMenu, teleportService,
+            requiredPlayerLevel);
         getCommand("fishing").setExecutor(new FishingCommand(mainMenu, adminMenu, requiredPlayerLevel));
 
         getLogger().info("FishingPlugin enabled");

--- a/src/main/java/org/maks/fishingPlugin/gui/MainMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/MainMenu.java
@@ -4,17 +4,23 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.service.TeleportService;
 
 public class MainMenu {
 
   private final QuickSellMenu quickSellMenu;
   private final RodShopMenu rodShopMenu;
   private final QuestMenu questMenu;
+  private final TeleportService teleportService;
+  private final int requiredLevel;
 
-  public MainMenu(QuickSellMenu quickSellMenu, RodShopMenu rodShopMenu, QuestMenu questMenu) {
+  public MainMenu(QuickSellMenu quickSellMenu, RodShopMenu rodShopMenu, QuestMenu questMenu,
+      TeleportService teleportService, int requiredLevel) {
     this.quickSellMenu = quickSellMenu;
     this.rodShopMenu = rodShopMenu;
     this.questMenu = questMenu;
+    this.teleportService = teleportService;
+    this.requiredLevel = requiredLevel;
   }
 
   public void open(Player player) {
@@ -29,6 +35,15 @@ public class MainMenu {
         .append(Component.newline())
         .append(Component.text("[Quests]").color(NamedTextColor.GOLD)
             .clickEvent(ClickEvent.callback(audience -> questMenu.open(player))))
+        .append(Component.newline())
+        .append(Component.text("[Przenieś na łowisko]").color(NamedTextColor.DARK_GREEN)
+            .clickEvent(ClickEvent.callback(audience -> {
+              if (player.getLevel() < requiredLevel) {
+                player.sendMessage("You need level " + requiredLevel + " to teleport.");
+                return;
+              }
+              teleportService.teleport("fishing_main", player);
+            })))
         .build();
     player.sendMessage(menu);
   }


### PR DESCRIPTION
## Summary
- Wire up `TeleportService` in `FishingPlugin` and provide it to the main menu
- Add "Przenieś na łowisko" menu option that teleports players to `fishing_main`
- Check player level before allowing teleport

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ecfb14428832ab76d6d913572d0f5