### PR TITLE
Persist rod levels via profile repository and add profile listener

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/listener/ProfileListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/ProfileListener.java
@@ -1,0 +1,29 @@
+package org.maks.fishingPlugin.listener;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.maks.fishingPlugin.service.LevelService;
+
+/**
+ * Loads and saves player profiles on join and quit.
+ */
+public class ProfileListener implements Listener {
+
+  private final LevelService levelService;
+
+  public ProfileListener(LevelService levelService) {
+    this.levelService = levelService;
+  }
+
+  @EventHandler
+  public void onJoin(PlayerJoinEvent event) {
+    levelService.loadProfile(event.getPlayer());
+  }
+
+  @EventHandler
+  public void onQuit(PlayerQuitEvent event) {
+    levelService.saveProfile(event.getPlayer());
+  }
+}


### PR DESCRIPTION
## Summary
- Load and save rod level/XP using `ProfileRepo` instead of persistent data container
- Add join/quit listener to manage profile loading and saving
- Register new listener and save profiles on plugin shutdown

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ed2d9d48c832a91f47dd7ec92689b