### PR TITLE
feat: add inventory based menus

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -36,6 +36,8 @@ import org.maks.fishingPlugin.gui.ShopMenu;
 import org.maks.fishingPlugin.gui.QuestMenu;
 import org.maks.fishingPlugin.gui.AdminLootEditorMenu;
 import org.maks.fishingPlugin.gui.AdminQuestEditorMenu;
+import org.maks.fishingPlugin.gui.PriceListMenu;
+import org.maks.fishingPlugin.gui.StatsMenu;
 import net.milkbowl.vault.economy.Economy;
 
 public final class FishingPlugin extends JavaPlugin {
@@ -177,11 +179,19 @@ public final class FishingPlugin extends JavaPlugin {
         QuickSellMenu quickSellMenu = new QuickSellMenu(quickSellService);
         ShopMenu shopMenu = new ShopMenu(this);
         QuestMenu questMenu = new QuestMenu(questService);
+        PriceListMenu priceListMenu = new PriceListMenu(lootService, quickSellService);
+        StatsMenu statsMenu = new StatsMenu(levelService, lootService);
         AdminQuestEditorMenu adminQuestMenu = new AdminQuestEditorMenu(questService, questRepo);
         AdminLootEditorMenu adminMenu = new AdminLootEditorMenu(lootService, lootRepo, paramRepo, adminQuestMenu);
-        MainMenu mainMenu = new MainMenu(quickSellMenu, shopMenu, questMenu, teleportService,
-            requiredPlayerLevel);
+        MainMenu mainMenu = new MainMenu(quickSellMenu, shopMenu, questMenu, priceListMenu, statsMenu,
+            teleportService, requiredPlayerLevel);
         getCommand("fishing").setExecutor(new FishingCommand(mainMenu, adminMenu, requiredPlayerLevel));
+
+        Bukkit.getPluginManager().registerEvents(mainMenu, this);
+        Bukkit.getPluginManager().registerEvents(quickSellMenu, this);
+        Bukkit.getPluginManager().registerEvents(questMenu, this);
+        Bukkit.getPluginManager().registerEvents(adminMenu, this);
+        Bukkit.getPluginManager().registerEvents(adminQuestMenu, this);
 
         getLogger().info("FishingPlugin enabled");
     }

--- a/src/main/java/org/maks/fishingPlugin/gui/AdminQuestEditorMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/AdminQuestEditorMenu.java
@@ -1,16 +1,26 @@
 package org.maks.fishingPlugin.gui;
 
 import java.sql.SQLException;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.event.ClickEvent;
-import net.kyori.adventure.text.format.NamedTextColor;
+import java.util.HashMap;
+import java.util.Map;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import net.kyori.adventure.text.Component;
 import org.maks.fishingPlugin.data.QuestRepo;
 import org.maks.fishingPlugin.model.QuestStage;
 import org.maks.fishingPlugin.service.QuestChainService;
 
-/** Simple chat-based quest reward editor. */
-public class AdminQuestEditorMenu {
+/** Inventory based quest reward editor for administrators. */
+public class AdminQuestEditorMenu implements Listener {
 
   private final QuestChainService questService;
   private final QuestRepo questRepo;
@@ -20,21 +30,48 @@ public class AdminQuestEditorMenu {
     this.questRepo = questRepo;
   }
 
-  public void open(Player player) {
-    Component menu = Component.text("Quest Editor").color(NamedTextColor.GOLD);
+  private Inventory createInventory() {
+    Map<Integer, QuestStage> map = new HashMap<>();
+    Inventory inv = Bukkit.createInventory(new Holder(map), 27, "Quest Editor");
+    int slot = 0;
     for (QuestStage stage : questService.getStages()) {
-      Component line = Component.text()
-          .append(Component.newline())
-          .append(Component.text("Stage " + stage.stage() + " reward: " +
-              String.format("%.0f", stage.reward())))
-          .append(Component.text(" [+]").color(NamedTextColor.GREEN)
-              .clickEvent(ClickEvent.callback(a -> adjust(stage, 10.0, player))))
-          .append(Component.text(" [-]").color(NamedTextColor.RED)
-              .clickEvent(ClickEvent.callback(a -> adjust(stage, -10.0, player))))
-          .build();
-      menu = menu.append(line);
+      ItemStack item = new ItemStack(Material.PAPER);
+      ItemMeta meta = item.getItemMeta();
+      if (meta != null) {
+        meta.displayName(Component.text("Stage " + stage.stage()));
+        java.util.List<Component> lore = new java.util.ArrayList<>();
+        lore.add(Component.text("Goal: " + stage.goal()));
+        lore.add(Component.text("Reward: " + String.format("%.0f", stage.reward())));
+        lore.add(Component.text("Left-click +10, Right-click -10"));
+        meta.lore(lore);
+        item.setItemMeta(meta);
+      }
+      inv.setItem(slot, item);
+      map.put(slot, stage);
+      slot++;
     }
-    player.sendMessage(menu);
+    return inv;
+  }
+
+  /** Open the quest editor menu. */
+  public void open(Player player) {
+    player.openInventory(createInventory());
+  }
+
+  @EventHandler
+  public void onClick(InventoryClickEvent event) {
+    if (!(event.getInventory().getHolder() instanceof Holder holder)) {
+      return;
+    }
+    event.setCancelled(true);
+    Player player = (Player) event.getWhoClicked();
+    QuestStage stage = holder.map.get(event.getRawSlot());
+    if (stage == null) {
+      return;
+    }
+    double delta = event.getClick() == ClickType.RIGHT ? -10.0 : 10.0;
+    adjust(stage, delta, player);
+    player.openInventory(createInventory());
   }
 
   private void adjust(QuestStage stage, double delta, Player player) {
@@ -46,6 +83,17 @@ public class AdminQuestEditorMenu {
     } catch (SQLException e) {
       player.sendMessage("DB error: " + e.getMessage());
     }
-    open(player);
+  }
+
+  private static class Holder implements InventoryHolder {
+    final Map<Integer, QuestStage> map;
+    Holder(Map<Integer, QuestStage> map) {
+      this.map = map;
+    }
+    @Override
+    public Inventory getInventory() {
+      return null;
+    }
   }
 }
+

--- a/src/main/java/org/maks/fishingPlugin/gui/MainMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/MainMenu.java
@@ -1,50 +1,99 @@
 package org.maks.fishingPlugin.gui;
 
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.event.ClickEvent;
-import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import net.kyori.adventure.text.Component;
 import org.maks.fishingPlugin.service.TeleportService;
 
-public class MainMenu {
+/**
+ * Inventory based main menu providing access to the various plugin features.
+ */
+public class MainMenu implements Listener {
 
   private final QuickSellMenu quickSellMenu;
   private final ShopMenu shopMenu;
   private final QuestMenu questMenu;
+  private final PriceListMenu priceListMenu;
+  private final StatsMenu statsMenu;
   private final TeleportService teleportService;
   private final int requiredLevel;
 
   public MainMenu(QuickSellMenu quickSellMenu, ShopMenu shopMenu, QuestMenu questMenu,
-      TeleportService teleportService, int requiredLevel) {
+      PriceListMenu priceListMenu, StatsMenu statsMenu, TeleportService teleportService,
+      int requiredLevel) {
     this.quickSellMenu = quickSellMenu;
     this.shopMenu = shopMenu;
     this.questMenu = questMenu;
+    this.priceListMenu = priceListMenu;
+    this.statsMenu = statsMenu;
     this.teleportService = teleportService;
     this.requiredLevel = requiredLevel;
   }
 
+  private ItemStack button(Material mat, String name) {
+    ItemStack item = new ItemStack(mat);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(name));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private Inventory createInventory() {
+    Inventory inv = Bukkit.createInventory(new Holder(), 27, "Fishing Menu");
+    inv.setItem(10, button(Material.CHEST, "Quick Sell"));
+    inv.setItem(11, button(Material.EMERALD, "Shop"));
+    inv.setItem(12, button(Material.BOOK, "Quests"));
+    inv.setItem(13, button(Material.PAPER, "Price List"));
+    inv.setItem(14, button(Material.OAK_SIGN, "Stats"));
+    inv.setItem(16, button(Material.ENDER_PEARL, "Teleport"));
+    return inv;
+  }
+
+  /** Open the main menu. */
   public void open(Player player) {
-    Component menu = Component.text()
-        .append(Component.text("Fishing Menu").color(NamedTextColor.AQUA))
-        .append(Component.newline())
-        .append(Component.text("[Quick Sell]").color(NamedTextColor.GREEN)
-            .clickEvent(ClickEvent.callback(audience -> quickSellMenu.open(player))))
-        .append(Component.newline())
-        .append(Component.text("[Shop]").color(NamedTextColor.BLUE)
-            .clickEvent(ClickEvent.callback(audience -> shopMenu.open(player))))
-        .append(Component.newline())
-        .append(Component.text("[Quests]").color(NamedTextColor.GOLD)
-            .clickEvent(ClickEvent.callback(audience -> questMenu.open(player))))
-        .append(Component.newline())
-        .append(Component.text("[Teleport to fishing area]").color(NamedTextColor.DARK_GREEN)
-            .clickEvent(ClickEvent.callback(audience -> {
-              if (player.getLevel() < requiredLevel) {
-                player.sendMessage("You need level " + requiredLevel + " to teleport.");
-                return;
-              }
-              teleportService.teleport("fishing_main", player);
-            })))
-        .build();
-    player.sendMessage(menu);
+    player.openInventory(createInventory());
+  }
+
+  @EventHandler
+  public void onClick(InventoryClickEvent event) {
+    if (!(event.getInventory().getHolder() instanceof Holder)) {
+      return;
+    }
+    event.setCancelled(true);
+    Player player = (Player) event.getWhoClicked();
+    switch (event.getRawSlot()) {
+      case 10 -> quickSellMenu.open(player);
+      case 11 -> shopMenu.open(player);
+      case 12 -> questMenu.open(player);
+      case 13 -> priceListMenu.open(player);
+      case 14 -> statsMenu.open(player);
+      case 16 -> {
+        if (player.getLevel() < requiredLevel) {
+          player.sendMessage("You need level " + requiredLevel + " to teleport.");
+        } else {
+          teleportService.teleport("fishing_main", player);
+        }
+      }
+      default -> {
+      }
+    }
+  }
+
+  private static class Holder implements InventoryHolder {
+    @Override
+    public Inventory getInventory() {
+      return null;
+    }
   }
 }
+

--- a/src/main/java/org/maks/fishingPlugin/gui/PriceListMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/PriceListMenu.java
@@ -1,0 +1,71 @@
+package org.maks.fishingPlugin.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import net.kyori.adventure.text.Component;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.LootEntry;
+import org.maks.fishingPlugin.service.LootService;
+import org.maks.fishingPlugin.service.QuickSellService;
+import org.maks.fishingPlugin.util.ItemSerialization;
+
+/**
+ * Simple inventory menu displaying the configured prices for fish loot
+ * entries.  The menu is informational only and contains no interactive
+ * elements.
+ */
+public class PriceListMenu {
+
+  private final LootService lootService;
+  private final QuickSellService quickSellService;
+
+  public PriceListMenu(LootService lootService, QuickSellService quickSellService) {
+    this.lootService = lootService;
+    this.quickSellService = quickSellService;
+  }
+
+  /** Open the price list inventory for the player. */
+  public void open(Player player) {
+    List<LootEntry> entries = lootService.getEntries();
+    int size = ((entries.size() / 9) + 1) * 9;
+    if (size > 54) {
+      size = 54; // limit to one double chest
+    }
+    Inventory inv = Bukkit.createInventory(null, size, "Price List");
+
+    String symbol = quickSellService.currencySymbol();
+    for (LootEntry entry : entries) {
+      if (entry.category() != Category.FISH && entry.category() != Category.FISH_PREMIUM) {
+        continue; // only list fish
+      }
+      ItemStack item;
+      try {
+        item = ItemSerialization.fromBase64(entry.itemBase64());
+      } catch (Exception ex) {
+        item = new ItemStack(org.bukkit.Material.PAPER);
+      }
+      ItemMeta meta = item.getItemMeta();
+      List<Component> lore = new ArrayList<>();
+      lore.add(Component.text("Base: " + symbol + String.format("%.2f", entry.priceBase())));
+      lore.add(Component.text("Per Kg: " + symbol + String.format("%.2f", entry.pricePerKg())));
+      lore.add(Component.text("Weight: " + String.format("%.0f-%.0f g", entry.minWeightG(), entry.maxWeightG())));
+      if (meta != null) {
+        meta.displayName(Component.text(entry.key()));
+        meta.lore(lore);
+        item.setItemMeta(meta);
+      }
+      inv.addItem(item);
+      if (inv.firstEmpty() == -1) {
+        break; // inventory full
+      }
+    }
+
+    player.openInventory(inv);
+  }
+}
+

--- a/src/main/java/org/maks/fishingPlugin/gui/QuickSellMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/QuickSellMenu.java
@@ -4,14 +4,24 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.event.ClickEvent;
-import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import net.kyori.adventure.text.Component;
 import org.maks.fishingPlugin.model.SellSummary;
 import org.maks.fishingPlugin.service.QuickSellService;
 
-public class QuickSellMenu {
+/**
+ * Inventory based quick sell menu allowing selection of fish to sell.
+ */
+public class QuickSellMenu implements Listener {
 
   private final QuickSellService quickSellService;
   private final Map<java.util.UUID, Set<String>> selections = new HashMap<>();
@@ -20,57 +30,99 @@ public class QuickSellMenu {
     this.quickSellService = quickSellService;
   }
 
-  public void open(Player player) {
+  private ItemStack entryItem(SellSummary.Entry e, boolean selected) {
+    ItemStack item = new ItemStack(selected ? Material.LIME_DYE : Material.GRAY_DYE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(e.key() + " [" + e.quality() + "]"));
+      java.util.List<Component> lore = new java.util.ArrayList<>();
+      lore.add(Component.text("Amount: " + e.amount()));
+      lore.add(Component.text("Price: " + quickSellService.currencySymbol()
+          + String.format("%.2f", e.price())));
+      meta.lore(lore);
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack button(Material mat, String name) {
+    ItemStack item = new ItemStack(mat);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.displayName(Component.text(name));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private Inventory createInventory(Player player) {
     SellSummary summary = quickSellService.summarize(player);
     Set<String> sel = selections.computeIfAbsent(player.getUniqueId(), k -> new HashSet<>());
-    Component menu = Component.text()
-        .append(Component.text("Quick Sell").color(NamedTextColor.GREEN))
-        .append(Component.newline());
-
+    Inventory inv = Bukkit.createInventory(new Holder(summary), 54, "Quick Sell");
+    int slot = 0;
     for (SellSummary.Entry e : summary.entries()) {
       String gk = QuickSellService.groupKey(e.key(), e.quality());
       boolean selected = sel.contains(gk);
-      Component line = Component.text(e.key() + " [" + e.quality() + "] x" + e.amount() + " = "
-          + quickSellService.currencySymbol() + String.format("%.2f", e.price()))
-          .color(selected ? NamedTextColor.GREEN : NamedTextColor.WHITE)
-          .append(Component.text(selected ? " [Unselect]" : " [Select]")
-              .color(NamedTextColor.AQUA)
-              .clickEvent(ClickEvent.callback(a -> {
-                if (selected) {
-                  sel.remove(gk);
-                } else {
-                  sel.add(gk);
-                }
-                open(player);
-              })));
-      menu = menu.append(line).append(Component.newline());
+      ItemStack item = entryItem(e, selected);
+      inv.setItem(slot++, item);
     }
+    inv.setItem(52, button(Material.GOLD_INGOT, "Sell Selected"));
+    inv.setItem(53, button(Material.REDSTONE_BLOCK, "Sell All"));
+    return inv;
+  }
 
-    menu = menu
-        .append(Component.text("Total: " + quickSellService.currencySymbol()
-            + String.format("%.2f", summary.totalPrice())).color(NamedTextColor.YELLOW))
-        .append(Component.newline())
-        .append(Component.text("[Sell Selected]").color(NamedTextColor.GOLD)
-            .clickEvent(ClickEvent.callback(a -> {
-              double amount = quickSellService.sellSelected(player, sel);
-              player.sendMessage(Component.text("Sold fish for "
-                  + quickSellService.currencySymbol() + String.format("%.2f", amount))
-                  .color(NamedTextColor.YELLOW));
-              sel.clear();
-              open(player);
-            })))
-        .append(Component.space())
-        .append(Component.text("[Sell All]").color(NamedTextColor.RED)
-            .clickEvent(ClickEvent.callback(a -> {
-              double amount = quickSellService.sellAll(player);
-              player.sendMessage(Component.text("Sold fish for "
-                  + quickSellService.currencySymbol() + String.format("%.2f", amount))
-                  .color(NamedTextColor.YELLOW));
-              sel.clear();
-              open(player);
-            })))
-        .build();
+  /** Open the quick sell menu. */
+  public void open(Player player) {
+    player.openInventory(createInventory(player));
+  }
 
-    player.sendMessage(menu);
+  @EventHandler
+  public void onClick(InventoryClickEvent event) {
+    if (!(event.getInventory().getHolder() instanceof Holder holder)) {
+      return;
+    }
+    event.setCancelled(true);
+    Player player = (Player) event.getWhoClicked();
+    Set<String> sel = selections.computeIfAbsent(player.getUniqueId(), k -> new HashSet<>());
+
+    int slot = event.getRawSlot();
+    if (slot == 52) {
+      double amount = quickSellService.sellSelected(player, sel);
+      player.sendMessage("Sold fish for " + quickSellService.currencySymbol()
+          + String.format("%.2f", amount));
+      sel.clear();
+      open(player);
+      return;
+    }
+    if (slot == 53) {
+      double amount = quickSellService.sellAll(player);
+      player.sendMessage("Sold fish for " + quickSellService.currencySymbol()
+          + String.format("%.2f", amount));
+      sel.clear();
+      open(player);
+      return;
+    }
+    if (slot >= 0 && slot < holder.summary.entries().size()) {
+      SellSummary.Entry e = holder.summary.entries().get(slot);
+      String gk = QuickSellService.groupKey(e.key(), e.quality());
+      if (sel.contains(gk)) {
+        sel.remove(gk);
+      } else {
+        sel.add(gk);
+      }
+      open(player);
+    }
+  }
+
+  private static class Holder implements InventoryHolder {
+    final SellSummary summary;
+    Holder(SellSummary summary) {
+      this.summary = summary;
+    }
+    @Override
+    public Inventory getInventory() {
+      return null;
+    }
   }
 }
+

--- a/src/main/java/org/maks/fishingPlugin/gui/StatsMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/StatsMenu.java
@@ -1,0 +1,90 @@
+package org.maks.fishingPlugin.gui;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import net.kyori.adventure.text.Component;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.LootEntry;
+import org.maks.fishingPlugin.model.ScaleConf;
+import org.maks.fishingPlugin.service.LevelService;
+import org.maks.fishingPlugin.service.LootService;
+
+/**
+ * Inventory menu showing player specific statistics such as rod level,
+ * experience and the percentage chance of each loot category.
+ */
+public class StatsMenu {
+
+  private final LevelService levelService;
+  private final LootService lootService;
+
+  public StatsMenu(LevelService levelService, LootService lootService) {
+    this.levelService = levelService;
+    this.lootService = lootService;
+  }
+
+  /** Open the stats inventory for the player. */
+  public void open(Player player) {
+    int level = levelService.getLevel(player);
+    long xp = levelService.getXp(player);
+    long needed = levelService.neededExp(level);
+
+    Inventory inv = Bukkit.createInventory(null, 27, "Stats");
+    ItemStack info = new ItemStack(Material.FISHING_ROD);
+    ItemMeta meta = info.getItemMeta();
+    List<Component> lore = new ArrayList<>();
+    lore.add(Component.text("Level: " + level));
+    lore.add(Component.text("XP: " + xp + "/" + needed));
+    if (meta != null) {
+      meta.displayName(Component.text("Rod"));
+      meta.lore(lore);
+      info.setItemMeta(meta);
+    }
+    inv.setItem(10, info);
+
+    // Compute category percentages based on effective weights
+    Map<Category, Double> weights = new EnumMap<>(Category.class);
+    double total = 0.0;
+    for (LootEntry e : lootService.getEntries()) {
+      if (level < e.minRodLevel()) {
+        continue;
+      }
+      ScaleConf conf = lootService.getScale(e.category());
+      double w = e.baseWeight();
+      if (conf != null) {
+        w *= conf.mult(level);
+      }
+      weights.merge(e.category(), w, Double::sum);
+      total += w;
+    }
+    int slot = 12;
+    for (Category cat : Category.values()) {
+      double w = weights.getOrDefault(cat, 0.0);
+      double pct = total > 0 ? (w / total) * 100.0 : 0.0;
+      ItemStack catItem = new ItemStack(Material.PAPER);
+      ItemMeta m = catItem.getItemMeta();
+      List<Component> l = new ArrayList<>();
+      l.add(Component.text(String.format("%.1f%%", pct)));
+      if (m != null) {
+        m.displayName(Component.text(cat.name()));
+        m.lore(l);
+        catItem.setItemMeta(m);
+      }
+      inv.setItem(slot++, catItem);
+      if (slot >= inv.getSize()) {
+        break;
+      }
+    }
+
+    player.openInventory(inv);
+  }
+}
+


### PR DESCRIPTION
## Summary
- replace chat menus with inventory interfaces for main, quick sell, quest and admin menus
- introduce price list and stats inventories
- register menu listeners and hook into command

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689ed599c6e8832aac691de445c7f802