### PR TITLE
Add MirrorItem support for non-fish loot

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/data/MirrorItemRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/MirrorItemRepo.java
@@ -1,0 +1,39 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.maks.fishingPlugin.model.Category;
+import org.maks.fishingPlugin.model.MirrorItem;
+
+/** Repository providing mirror items. */
+public class MirrorItemRepo {
+
+  private final DataSource dataSource;
+
+  public MirrorItemRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public List<MirrorItem> findAll() throws SQLException {
+    String sql = "SELECT key, category, broadcast, item_base64 FROM mirror_item";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql);
+         ResultSet rs = ps.executeQuery()) {
+      List<MirrorItem> list = new ArrayList<>();
+      while (rs.next()) {
+        list.add(new MirrorItem(
+            rs.getString(1),
+            Category.valueOf(rs.getString(2)),
+            rs.getBoolean(3),
+            rs.getString(4)
+        ));
+      }
+      return list;
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/model/MirrorItem.java
+++ b/src/main/java/org/maks/fishingPlugin/model/MirrorItem.java
@@ -1,0 +1,12 @@
+package org.maks.fishingPlugin.model;
+
+/**
+ * Definition of a non-fish loot item stored separately from loot entries.
+ * The item is stored as a Base64 encoded ItemStack.
+ */
+public record MirrorItem(
+    String key,
+    Category category,
+    boolean broadcast,
+    String itemBase64
+) {}

--- a/src/main/java/org/maks/fishingPlugin/service/MirrorItemService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/MirrorItemService.java
@@ -1,0 +1,27 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.maks.fishingPlugin.model.MirrorItem;
+
+/** In-memory repository of mirror items. */
+public class MirrorItemService {
+
+  private final Map<String, MirrorItem> byKey = new HashMap<>();
+
+  /** Register a mirror item. */
+  public void add(MirrorItem item) {
+    byKey.put(item.key(), item);
+  }
+
+  /** Retrieve a mirror item by key. */
+  public MirrorItem get(String key) {
+    return byKey.get(key);
+  }
+
+  /** Expose registered items. */
+  public List<MirrorItem> getAll() {
+    return List.copyOf(byKey.values());
+  }
+}


### PR DESCRIPTION
## Summary
- introduce MirrorItem model, repository and service for Base64 item definitions
- load mirror items on startup and hand them to Awarder
- update Awarder to build items from mirror definitions and respect broadcast flags

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ed90a07e8832a8c59cc0f42773243