### PR TITLE
Add price list and stats menus with level gating

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/gui/MainMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/MainMenu.java
@@ -59,8 +59,12 @@ public class MainMenu implements Listener {
     return inv;
   }
 
-  /** Open the main menu. */
+  /** Open the main menu if the player meets the level requirement. */
   public void open(Player player) {
+    if (player.getLevel() < requiredLevel) {
+      player.sendMessage("You need level " + requiredLevel + " to use fishing features.");
+      return;
+    }
     player.openInventory(createInventory());
   }
 

--- a/src/main/java/org/maks/fishingPlugin/gui/StatsMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/StatsMenu.java
@@ -13,7 +13,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import net.kyori.adventure.text.Component;
 import org.maks.fishingPlugin.model.Category;
 import org.maks.fishingPlugin.model.LootEntry;
-import org.maks.fishingPlugin.model.ScaleConf;
 import org.maks.fishingPlugin.service.LevelService;
 import org.maks.fishingPlugin.service.LootService;
 
@@ -54,14 +53,7 @@ public class StatsMenu {
     Map<Category, Double> weights = new EnumMap<>(Category.class);
     double total = 0.0;
     for (LootEntry e : lootService.getEntries()) {
-      if (level < e.minRodLevel()) {
-        continue;
-      }
-      ScaleConf conf = lootService.getScale(e.category());
-      double w = e.baseWeight();
-      if (conf != null) {
-        w *= conf.mult(level);
-      }
+      double w = lootService.effectiveWeight(e, level);
       weights.merge(e.category(), w, Double::sum);
       total += w;
     }

--- a/src/main/java/org/maks/fishingPlugin/service/LootService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LootService.java
@@ -72,7 +72,11 @@ public class LootService {
     return byKey.get(key);
   }
 
-  double effectiveWeight(LootEntry e, int rodLevel) {
+  /**
+   * Calculates the effective weight for the given loot entry at the specified
+   * rod level after applying category scaling and level requirements.
+   */
+  public double effectiveWeight(LootEntry e, int rodLevel) {
     if (rodLevel < e.minRodLevel()) {
       return 0.0;
     }


### PR DESCRIPTION
## Summary
- expose `LootService.effectiveWeight` for other components
- show level, XP and loot category odds in the new stats menu
- gate main menu by player level and include price list links

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689edd6e6c68832aae936c410cb99253