### PR TITLE
Randomize QTE timing for autofish protection

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -180,10 +180,18 @@ public final class FishingPlugin extends JavaPlugin {
 
         var qteSec = getConfig().getConfigurationSection("qte");
         int clicks = qteSec != null ? qteSec.getInt("clicks", 1) : 1;
-        long windowMs = qteSec != null ? qteSec.getLong("window_ms", 1000) : 1000;
+        java.util.List<Long> delayRange =
+            qteSec != null ? qteSec.getLongList("start_delay_ms") : java.util.List.of(650L, 1100L);
+        java.util.List<Long> windowRange =
+            qteSec != null ? qteSec.getLongList("window_len_ms") : java.util.List.of(350L, 700L);
+        long startDelayMin = delayRange.size() > 0 ? delayRange.get(0) : 650L;
+        long startDelayMax = delayRange.size() > 1 ? delayRange.get(1) : startDelayMin;
+        long windowMin = windowRange.size() > 0 ? windowRange.get(0) : 350L;
+        long windowMax = windowRange.size() > 1 ? windowRange.get(1) : windowMin;
         QteService.MacroAction macroAction = QteService.MacroAction.valueOf(actionStr.toUpperCase());
 
-        this.qteService = new QteService(antiCheatService, clicks, windowMs, macroAction);
+        this.qteService = new QteService(this, antiCheatService, clicks, startDelayMin, startDelayMax,
+            windowMin, windowMax, macroAction);
         this.teleportService = new TeleportService(this);
         this.questService = new QuestChainService(economy, questRepo, questProgressRepo, this);
         if (pm.getPlugin("PlaceholderAPI") != null) {

--- a/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
@@ -51,7 +51,7 @@ public class FishingListener implements Listener {
       return;
     }
     if (event.getState() == PlayerFishEvent.State.BITE) {
-      qteService.start(player);
+      qteService.start(player); // start QTE with randomized timing
       return;
     }
     if (event.getState() != PlayerFishEvent.State.CAUGHT_FISH) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,7 +9,8 @@ database:
 
 qte:
   clicks: 1
-  window_ms: 1000
+  start_delay_ms: [650, 1100]
+  window_len_ms: [350, 700]
 
 anti_cheat:
   sample_size: 5


### PR DESCRIPTION
## Summary
- Randomize start delay and click window in QTE anti-autofish mechanic
- Load QTE timing ranges from config and schedule message after delay
- Document new QTE timing settings in default configuration

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ee10d3adc832ab63c5944a0151e59