### PR TITLE
Check player level before opening shop

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -206,7 +206,7 @@ public final class FishingPlugin extends JavaPlugin {
         Bukkit.getOnlinePlayers().forEach(levelService::loadProfile);
 
         QuickSellMenu quickSellMenu = new QuickSellMenu(quickSellService);
-        ShopMenu shopMenu = new ShopMenu(this);
+        ShopMenu shopMenu = new ShopMenu(this, requiredPlayerLevel);
         QuestMenu questMenu = new QuestMenu(questService);
         PriceListMenu priceListMenu = new PriceListMenu(lootService, quickSellService);
         StatsMenu statsMenu = new StatsMenu(levelService, lootService);

--- a/src/main/java/org/maks/fishingPlugin/gui/ShopMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/ShopMenu.java
@@ -10,16 +10,23 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class ShopMenu {
 
   private final JavaPlugin plugin;
+  private final int requiredLevel;
 
-  public ShopMenu(JavaPlugin plugin) {
+  public ShopMenu(JavaPlugin plugin, int requiredLevel) {
     this.plugin = plugin;
+    this.requiredLevel = requiredLevel;
   }
 
   /**
    * Grant temporary permission and execute the fisherman shop command.
    */
   public void open(Player player) {
-    PermissionAttachment attachment = player.addAttachment(plugin, "mycraftingplugin.use", true);
+    if (player.getLevel() < requiredLevel) {
+      player.sendMessage("You need level " + requiredLevel + " to access the shop.");
+      return;
+    }
+    PermissionAttachment attachment =
+        player.addAttachment(plugin, "mycraftingplugin.use", true);
     player.performCommand("fisherman_shop");
     player.removeAttachment(attachment);
   }


### PR DESCRIPTION
## Summary
- require a minimum player level before opening the shop and sending the permission
- pass configured level requirement to `ShopMenu`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ee2979454832a9ba73d3619fc3de9