### PR TITLE
Add economy settings editor

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -211,7 +211,8 @@ public final class FishingPlugin extends JavaPlugin {
         PriceListMenu priceListMenu = new PriceListMenu(lootService, quickSellService);
         StatsMenu statsMenu = new StatsMenu(levelService, lootService);
         AdminQuestEditorMenu adminQuestMenu = new AdminQuestEditorMenu(this, questService, questRepo);
-        AdminLootEditorMenu adminMenu = new AdminLootEditorMenu(lootService, lootRepo, paramRepo, adminQuestMenu);
+        AdminLootEditorMenu adminMenu = new AdminLootEditorMenu(this, lootService, lootRepo, paramRepo,
+            quickSellService, adminQuestMenu);
         MainMenu mainMenu = new MainMenu(quickSellMenu, shopMenu, questMenu, priceListMenu, statsMenu,
             teleportService, requiredPlayerLevel);
         getCommand("fishing").setExecutor(new FishingCommand(mainMenu, adminMenu, requiredPlayerLevel));

--- a/src/main/java/org/maks/fishingPlugin/service/QuickSellService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QuickSellService.java
@@ -21,9 +21,9 @@ public class QuickSellService {
   private final NamespacedKey keyKey;
   private final NamespacedKey weightKey;
   private final NamespacedKey qualityKey;
-  private final double globalMultiplier;
-  private final double tax;
-  private final String currencySymbol;
+  private double globalMultiplier;
+  private double tax;
+  private String currencySymbol;
 
   public QuickSellService(JavaPlugin plugin, LootService lootService, Economy economy,
       double globalMultiplier, double tax, String currencySymbol) {
@@ -148,5 +148,30 @@ public class QuickSellService {
 
   public String currencySymbol() {
     return currencySymbol;
+  }
+
+  /** Get the current global multiplier. */
+  public double globalMultiplier() {
+    return globalMultiplier;
+  }
+
+  /** Get the current quick sell tax. */
+  public double tax() {
+    return tax;
+  }
+
+  /** Update the global payout multiplier. */
+  public void setGlobalMultiplier(double globalMultiplier) {
+    this.globalMultiplier = globalMultiplier;
+  }
+
+  /** Update the quick sell tax. */
+  public void setTax(double tax) {
+    this.tax = tax;
+  }
+
+  /** Update the currency symbol used in menus. */
+  public void setCurrencySymbol(String currencySymbol) {
+    this.currencySymbol = currencySymbol;
   }
 }


### PR DESCRIPTION
## Summary
- extend quick sell service with adjustable multiplier, tax and currency symbol
- add economy editor to admin menu to tweak multiplier, tax and currency symbol
- wire admin menu with plugin quick sell service

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689eedc10804832a82d353d128c739be