### PR TITLE
feat: allow adding mirror items

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -212,7 +212,7 @@ public final class FishingPlugin extends JavaPlugin {
         StatsMenu statsMenu = new StatsMenu(levelService, lootService);
         AdminQuestEditorMenu adminQuestMenu = new AdminQuestEditorMenu(this, questService, questRepo);
         AdminLootEditorMenu adminMenu = new AdminLootEditorMenu(this, lootService, lootRepo, paramRepo,
-            quickSellService, adminQuestMenu);
+            quickSellService, adminQuestMenu, mirrorItemRepo, mirrorItemService);
         MainMenu mainMenu = new MainMenu(quickSellMenu, shopMenu, questMenu, priceListMenu, statsMenu,
             teleportService, requiredPlayerLevel);
         getCommand("fishing").setExecutor(new FishingCommand(mainMenu, adminMenu, requiredPlayerLevel));

--- a/src/main/java/org/maks/fishingPlugin/data/MirrorItemRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/MirrorItemRepo.java
@@ -36,4 +36,20 @@ public class MirrorItemRepo {
       return list;
     }
   }
+
+  /** Insert or update a mirror item definition. */
+  public void upsert(MirrorItem item) throws SQLException {
+    String sql =
+        "INSERT INTO fishing_mirror_item(`key`,category,broadcast,item_base64) VALUES (?,?,?,?) " +
+            "ON DUPLICATE KEY UPDATE category=VALUES(category), broadcast=VALUES(broadcast), " +
+            "item_base64=VALUES(item_base64)";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, item.key());
+      ps.setString(2, item.category().name());
+      ps.setBoolean(3, item.broadcast());
+      ps.setString(4, item.itemBase64());
+      ps.executeUpdate();
+    }
+  }
 }

--- a/src/test/java/org/maks/fishingPlugin/data/DatabaseIntegrationTest.java
+++ b/src/test/java/org/maks/fishingPlugin/data/DatabaseIntegrationTest.java
@@ -12,6 +12,8 @@ import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.maks.fishingPlugin.model.MirrorItem;
+import org.maks.fishingPlugin.model.Category;
 
 /** Integration test verifying MySQL migrations and data access. */
 public class DatabaseIntegrationTest {
@@ -51,5 +53,22 @@ public class DatabaseIntegrationTest {
         Optional<Profile> loaded = repo.find(id);
         assertTrue(loaded.isPresent());
         assertEquals(profile, loaded.get());
+    }
+
+    @Test
+    void testMirrorItemUpsert() throws SQLException {
+        DataSource ds = database.getDataSource();
+        MirrorItemRepo repo = new MirrorItemRepo(ds);
+        MirrorItem item = new MirrorItem("key1", Category.FISH, true, "data");
+        repo.upsert(item);
+        java.util.List<MirrorItem> all = repo.findAll();
+        assertEquals(1, all.size());
+        assertEquals(item, all.get(0));
+
+        MirrorItem updated = new MirrorItem("key1", Category.TREASURE, false, "data2");
+        repo.upsert(updated);
+        all = repo.findAll();
+        assertEquals(1, all.size());
+        assertEquals(updated, all.get(0));
     }
 }


### PR DESCRIPTION
## Summary
- add upsert support for mirror items
- allow admins to create mirror items from an in-game menu
- cover mirror item persistence with integration tests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f02d63ba4832a9224d6f507ed2fe1