### PR TITLE
Add configurable loot category weights

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -139,7 +139,12 @@ public final class FishingPlugin extends JavaPlugin {
                 } catch (IllegalArgumentException ignored) {}
             }
         }
-        this.lootService = new LootService(scaling);
+        Map<Category, Double> catWeights = new EnumMap<>(Category.class);
+        for (Category cat : Category.values()) {
+            double w = Double.parseDouble(params.getOrDefault("category_weight_" + cat.name(), "1.0"));
+            catWeights.put(cat, w);
+        }
+        this.lootService = new LootService(scaling, catWeights);
         try {
             for (LootEntry entry : lootRepo.findAll()) {
                 lootService.addEntry(entry);

--- a/src/main/java/org/maks/fishingPlugin/gui/StatsMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/StatsMenu.java
@@ -49,12 +49,15 @@ public class StatsMenu {
     }
     inv.setItem(10, info);
 
-    // Compute category percentages based on effective weights
+    // Compute category percentages based on base category weights
     Map<Category, Double> weights = new EnumMap<>(Category.class);
-    double total = 0.0;
     for (LootEntry e : lootService.getEntries()) {
-      double w = lootService.effectiveWeight(e, level);
-      weights.merge(e.category(), w, Double::sum);
+      if (lootService.effectiveWeight(e, level) > 0) {
+        weights.put(e.category(), lootService.getBaseCategoryWeight(e.category()));
+      }
+    }
+    double total = 0.0;
+    for (double w : weights.values()) {
       total += w;
     }
     int slot = 12;


### PR DESCRIPTION
## Summary
- add base category weights and two-stage loot roll
- expose category weight editing in admin menu with ParamRepo persistence
- show category chances based on base weights in stats menu

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `mvn -q -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f056cd970832a92c6243564378abf