### PR TITLE
Track quick sell earnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.10.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>ch.vorburger.mariaDB4j</groupId>
                 <artifactId>mariaDB4j</artifactId>
                 <version>2.7.5</version>

--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -173,7 +173,7 @@ public final class FishingPlugin extends JavaPlugin {
         multiplier = Double.parseDouble(params.getOrDefault("global_multiplier", String.valueOf(multiplier)));
         tax = Double.parseDouble(params.getOrDefault("quicksell_tax", String.valueOf(tax)));
         symbol = params.getOrDefault("currency_symbol", symbol);
-        this.quickSellService = new QuickSellService(this, lootService, economy, multiplier, tax, symbol);
+        this.quickSellService = new QuickSellService(this, lootService, economy, levelService, multiplier, tax, symbol);
 
         var acSec = getConfig().getConfigurationSection("anti_cheat");
         int sampleSize = acSec != null ? acSec.getInt("sample_size", 5) : 5;

--- a/src/main/java/org/maks/fishingPlugin/service/LevelService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LevelService.java
@@ -131,4 +131,13 @@ public class LevelService {
   public long getLargestCatchG(Player p) {
     return profile(p).largestCatchG();
   }
+
+  /** Increase the quick sell earnings counter for the player. */
+  public void addQsEarned(Player p, long amount) {
+    Profile old = profile(p);
+    profiles.put(p.getUniqueId(),
+        new Profile(p.getUniqueId(), old.rodLevel(), old.rodXp(), old.totalCatches(),
+            old.totalWeightG(), old.largestCatchG(), old.qsEarned() + amount,
+            old.lastQteSample(), old.createdAt(), Instant.now()));
+  }
 }

--- a/src/main/java/org/maks/fishingPlugin/service/QuickSellService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QuickSellService.java
@@ -18,6 +18,7 @@ public class QuickSellService {
 
   private final LootService lootService;
   private final Economy economy;
+  private final LevelService levelService;
   private final NamespacedKey keyKey;
   private final NamespacedKey weightKey;
   private final NamespacedKey qualityKey;
@@ -26,9 +27,10 @@ public class QuickSellService {
   private String currencySymbol;
 
   public QuickSellService(JavaPlugin plugin, LootService lootService, Economy economy,
-      double globalMultiplier, double tax, String currencySymbol) {
+      LevelService levelService, double globalMultiplier, double tax, String currencySymbol) {
     this.lootService = lootService;
     this.economy = economy;
+    this.levelService = levelService;
     this.globalMultiplier = globalMultiplier;
     this.tax = tax;
     this.currencySymbol = currencySymbol;
@@ -78,6 +80,7 @@ public class QuickSellService {
     if (total > 0) {
       double payout = total * (1.0 - tax);
       economy.depositPlayer(player, payout);
+      levelService.addQsEarned(player, Math.round(payout));
       return payout;
     }
     return 0;

--- a/src/test/java/org/maks/fishingPlugin/service/LevelServiceTest.java
+++ b/src/test/java/org/maks/fishingPlugin/service/LevelServiceTest.java
@@ -1,0 +1,39 @@
+package org.maks.fishingPlugin.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Logger;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.maks.fishingPlugin.data.Profile;
+import org.maks.fishingPlugin.data.ProfileRepo;
+
+public class LevelServiceTest {
+
+    @Test
+    void addQsEarnedUpdatesProfile() throws SQLException {
+        ProfileRepo repo = mock(ProfileRepo.class);
+        JavaPlugin plugin = mock(JavaPlugin.class);
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+        LevelService service = new LevelService(repo, plugin);
+
+        Player player = mock(Player.class);
+        UUID id = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(id);
+        when(repo.find(id)).thenReturn(Optional.empty());
+
+        service.loadProfile(player);
+        service.addQsEarned(player, 50L);
+        service.saveProfile(player);
+
+        ArgumentCaptor<Profile> captor = ArgumentCaptor.forClass(Profile.class);
+        verify(repo).upsert(captor.capture());
+        assertEquals(50L, captor.getValue().qsEarned());
+    }
+}


### PR DESCRIPTION
## Summary
- Record quick sell payouts in player profiles via LevelService
- Provide LevelService helper to increase quick sell earnings
- Wire LevelService into QuickSellService and add unit test

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f0a46b57c832aaa91805540831391