### PR TITLE
Persist anti-cheat samples across sessions

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/listener/ProfileListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/ProfileListener.java
@@ -4,6 +4,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.maks.fishingPlugin.service.AntiCheatService;
 import org.maks.fishingPlugin.service.LevelService;
 
 /**
@@ -12,18 +13,25 @@ import org.maks.fishingPlugin.service.LevelService;
 public class ProfileListener implements Listener {
 
   private final LevelService levelService;
+  private final AntiCheatService antiCheat;
 
-  public ProfileListener(LevelService levelService) {
+  public ProfileListener(LevelService levelService, AntiCheatService antiCheat) {
     this.levelService = levelService;
+    this.antiCheat = antiCheat;
   }
 
   @EventHandler
   public void onJoin(PlayerJoinEvent event) {
     levelService.loadProfile(event.getPlayer());
+    byte[] sample = levelService.getLastQteSample(event.getPlayer());
+    antiCheat.deserialize(event.getPlayer().getUniqueId(), sample);
   }
 
   @EventHandler
   public void onQuit(PlayerQuitEvent event) {
+    byte[] sample = antiCheat.serialize(event.getPlayer().getUniqueId());
+    levelService.setLastQteSample(event.getPlayer(), sample);
     levelService.saveProfile(event.getPlayer());
+    antiCheat.reset(event.getPlayer().getUniqueId());
   }
 }

--- a/src/main/java/org/maks/fishingPlugin/service/LevelService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LevelService.java
@@ -62,6 +62,20 @@ public class LevelService {
         new Profile(p.getUniqueId(), 0, 0, 0, 0, 0, 0, null, Instant.now(), Instant.now()));
   }
 
+  /** Get the stored anti-cheat sample for a player. */
+  public byte[] getLastQteSample(Player p) {
+    return profile(p).lastQteSample();
+  }
+
+  /** Update the stored anti-cheat sample for a player. */
+  public void setLastQteSample(Player p, byte[] sample) {
+    Profile old = profile(p);
+    profiles.put(p.getUniqueId(),
+        new Profile(p.getUniqueId(), old.rodLevel(), old.rodXp(), old.totalCatches(),
+            old.totalWeightG(), old.largestCatchG(), old.qsEarned(), sample,
+            old.createdAt(), Instant.now()));
+  }
+
   public int getLevel(Player p) {
     return profile(p).rodLevel();
   }

--- a/src/test/java/org/maks/fishingPlugin/data/DatabaseIntegrationTest.java
+++ b/src/test/java/org/maks/fishingPlugin/data/DatabaseIntegrationTest.java
@@ -48,7 +48,7 @@ public class DatabaseIntegrationTest {
         DataSource ds = database.getDataSource();
         ProfileRepo repo = new ProfileRepo(ds);
         UUID id = UUID.randomUUID();
-        Profile profile = new Profile(id, 5, 10L, 2L, 1500L, 800L, 0L, null,
+        Profile profile = new Profile(id, 5, 10L, 2L, 1500L, 800L, 0L, new byte[] {1,2,3},
                 java.time.Instant.now(), java.time.Instant.now());
         repo.upsert(profile);
         Optional<Profile> loaded = repo.find(id);

--- a/src/test/java/org/maks/fishingPlugin/service/AntiCheatServiceTest.java
+++ b/src/test/java/org/maks/fishingPlugin/service/AntiCheatServiceTest.java
@@ -1,0 +1,24 @@
+package org.maks.fishingPlugin.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class AntiCheatServiceTest {
+
+  @Test
+  void serializeDeserializePreservesSamples() {
+    AntiCheatService ac = new AntiCheatService(3, 5);
+    UUID id = UUID.randomUUID();
+    long base = 1000L;
+    ac.record(id, base + 100); // first click
+    ac.record(id, base + 200); // interval 100
+    ac.record(id, base + 302); // interval 102
+    byte[] data = ac.serialize(id);
+
+    AntiCheatService ac2 = new AntiCheatService(3, 5);
+    ac2.deserialize(id, data);
+    assertTrue(ac2.record(id, base + 400)); // interval 98 -> low variance
+  }
+}


### PR DESCRIPTION
## Summary
- serialize and deserialize QTE anti-cheat intervals
- load and save `last_qte_sample` on player join/quit
- test anti-cheat sample persistence and DB mapping

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b5b7b00832abd9f7f3ea9329bfa