### PR TITLE
Add configuration-driven mechanics and safeguards

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/command/FishingCommand.java
+++ b/src/main/java/org/maks/fishingPlugin/command/FishingCommand.java
@@ -36,6 +36,10 @@ public class FishingCommand implements CommandExecutor {
       adminMenu.open(player);
       return true;
     }
+    if (!player.hasPermission("fishing.use")) {
+      player.sendMessage("You don't have permission.");
+      return true;
+    }
     if (player.getLevel() < requiredLevel) {
       player.sendMessage("You need level " + requiredLevel + " to use fishing features.");
       return true;

--- a/src/main/java/org/maks/fishingPlugin/gui/StatsMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/StatsMenu.java
@@ -49,15 +49,15 @@ public class StatsMenu {
     }
     inv.setItem(10, info);
 
-    // Compute category percentages based on base category weights
+    // Compute category percentages based on effective weights of all entries
     Map<Category, Double> weights = new EnumMap<>(Category.class);
-    for (LootEntry e : lootService.getEntries()) {
-      if (lootService.effectiveWeight(e, level) > 0) {
-        weights.put(e.category(), lootService.getBaseCategoryWeight(e.category()));
-      }
-    }
     double total = 0.0;
-    for (double w : weights.values()) {
+    for (LootEntry e : lootService.getEntries()) {
+      double w = lootService.effectiveWeight(e, level);
+      if (w <= 0) {
+        continue;
+      }
+      weights.merge(e.category(), w, Double::sum);
       total += w;
     }
     int slot = 12;

--- a/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
@@ -58,7 +58,8 @@ public class FishingListener implements Listener {
       return;
     }
     event.setCancelled(true);
-    if (!qteService.consume(player)) {
+    QteService.Result qteResult = qteService.consume(player);
+    if (!qteResult.success()) {
       player.sendMessage("The fish got away!");
       return;
     }
@@ -74,7 +75,7 @@ public class FishingListener implements Listener {
       double kg = res.weightG() / 1000.0;
       player.sendMessage("You caught a fish weighing " + String.format("%.1f", kg) + "kg");
       int before = rodLevel;
-      int after = levelService.awardCatchExp(player, kg, true);
+      int after = levelService.awardCatchExp(player, kg, qteResult.perfect());
       if (after > before) {
         player.sendMessage("Your fishing rod leveled up to " + after + "!");
       }

--- a/src/main/java/org/maks/fishingPlugin/service/LevelService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LevelService.java
@@ -20,9 +20,25 @@ public class LevelService {
   private final Logger logger;
   private final Map<UUID, Profile> profiles = new HashMap<>();
 
-  public LevelService(ProfileRepo profileRepo, JavaPlugin plugin) {
+  private final double expBase;
+  private final double growthA;
+  private final double growthB;
+  private final double growthC;
+  private final double baseGain;
+  private final double weightFactor;
+  private final double qteBonus;
+
+  public LevelService(ProfileRepo profileRepo, JavaPlugin plugin, double expBase, double growthA,
+      double growthB, double growthC, double baseGain, double weightFactor, double qteBonus) {
     this.profileRepo = profileRepo;
     this.logger = plugin.getLogger();
+    this.expBase = expBase;
+    this.growthA = growthA;
+    this.growthB = growthB;
+    this.growthC = growthC;
+    this.baseGain = baseGain;
+    this.weightFactor = weightFactor;
+    this.qteBonus = qteBonus;
   }
 
   /**
@@ -101,12 +117,13 @@ public class LevelService {
    */
   public long neededExp(int level) {
     if (level < 15) {
-      return Math.round(150 * Math.pow(1.12, level));
+      return Math.round(expBase * Math.pow(growthA, level));
     }
     if (level < 30) {
-      return Math.round(150 * Math.pow(1.12, 15) * Math.pow(1.14, level - 15));
+      return Math.round(expBase * Math.pow(growthA, 15) * Math.pow(growthB, level - 15));
     }
-    return Math.round(150 * Math.pow(1.12, 15) * Math.pow(1.14, 15) * Math.pow(1.16, level - 30));
+    return Math.round(expBase * Math.pow(growthA, 15) * Math.pow(growthB, 15)
+        * Math.pow(growthC, level - 30));
   }
 
   /**
@@ -118,7 +135,7 @@ public class LevelService {
    * @return new rod level after applying experience
    */
   public int awardCatchExp(Player p, double weightKg, boolean perfect) {
-    long gain = Math.round(8 + 0.4 * weightKg + (perfect ? 3 : 0));
+    long gain = Math.round(baseGain + weightFactor * weightKg + (perfect ? qteBonus : 0));
     Profile prof = profile(p);
     long xp = prof.rodXp() + gain;
     int level = prof.rodLevel();

--- a/src/main/java/org/maks/fishingPlugin/service/QuickSellService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QuickSellService.java
@@ -25,15 +25,18 @@ public class QuickSellService {
   private double globalMultiplier;
   private double tax;
   private String currencySymbol;
+  private double maxItemPrice;
 
   public QuickSellService(JavaPlugin plugin, LootService lootService, Economy economy,
-      LevelService levelService, double globalMultiplier, double tax, String currencySymbol) {
+      LevelService levelService, double globalMultiplier, double tax, String currencySymbol,
+      double maxItemPrice) {
     this.lootService = lootService;
     this.economy = economy;
     this.levelService = levelService;
     this.globalMultiplier = globalMultiplier;
     this.tax = tax;
     this.currencySymbol = currencySymbol;
+    this.maxItemPrice = maxItemPrice;
     this.keyKey = new NamespacedKey(plugin, "loot-key");
     this.weightKey = new NamespacedKey(plugin, "weight-g");
     this.qualityKey = new NamespacedKey(plugin, "quality");
@@ -44,8 +47,13 @@ public class QuickSellService {
   }
 
   private double computePrice(LootEntry entry, double weight, int amount) {
-    return (entry.priceBase() + (weight / 1000.0) * entry.pricePerKg())
-        * entry.payoutMultiplier() * globalMultiplier * amount;
+    double perItem =
+        (entry.priceBase() + (weight / 1000.0) * entry.pricePerKg()) * entry.payoutMultiplier()
+            * globalMultiplier;
+    if (perItem > maxItemPrice) {
+      perItem = maxItemPrice;
+    }
+    return perItem * amount;
   }
 
   private double sell(Player player, java.util.function.Predicate<String> filter) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,26 @@ economy:
   currency_symbol: "$"
   quicksell_tax: 0.0
   global_multiplier: 1.0
+  max_price: 10000.0
+
+leveling:
+  exp_base: 150
+  growthA: 1.12
+  growthB: 1.14
+  growthC: 1.16
+
+exp_gain:
+  base: 8
+  weight_factor: 0.4
+  qte_bonus: 3
+
+base_category_weights:
+  FISH: 9500
+  FISH_PREMIUM: 350
+  RUNE: 80
+  TREASURE: 50
+  FISHERMAN_CHEST: 15
+  MATERIAL: 5
 
 warps:
   - key: fishing_main

--- a/src/test/java/org/maks/fishingPlugin/service/LevelServiceTest.java
+++ b/src/test/java/org/maks/fishingPlugin/service/LevelServiceTest.java
@@ -21,7 +21,7 @@ public class LevelServiceTest {
         ProfileRepo repo = mock(ProfileRepo.class);
         JavaPlugin plugin = mock(JavaPlugin.class);
         when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
-        LevelService service = new LevelService(repo, plugin);
+        LevelService service = new LevelService(repo, plugin, 150, 1.12, 1.14, 1.16, 8, 0.4, 3);
 
         Player player = mock(Player.class);
         UUID id = UUID.randomUUID();


### PR DESCRIPTION
## Summary
- require `fishing.use` permission for main command
- show real loot category chances in stats menu
- cap quick sell payouts per item via configurable `max_price`
- make leveling and EXP gain curves configurable
- detect perfect QTE hits and award bonus EXP
- load base category weights and economy settings from config

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689f12718f74832ab65a3360cb65a9ef