### PR TITLE
Fix Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
                 <version>8.0.33</version>
             </dependency>
             <dependency>
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>ch.vorburger.mariaDB4j</groupId>
                 <artifactId>mariaDB4j</artifactId>
-                <version>2.7.5</version>
+                <version>3.2.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
## Summary
- switch to `com.mysql:mysql-connector-j` coordinates
- upgrade MariaDB4j test dependency to 3.2.0

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f3a598a08832a87b794d8530f5330