### PR TITLE
Allow QTE to detect minimal mouse movement

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -193,8 +193,9 @@ public final class FishingPlugin extends JavaPlugin {
         var qteSec = getConfig().getConfigurationSection("qte");
         double chance = qteSec != null ? qteSec.getDouble("chance", 0.25) : 0.25;
         long duration = qteSec != null ? qteSec.getLong("duration_ms", 1000L) : 1000L;
+        float yawThreshold = qteSec != null ? (float) qteSec.getDouble("yaw_threshold", 1.0) : 1.0f;
 
-        this.qteService = new QteService(chance, duration);
+        this.qteService = new QteService(chance, duration, yawThreshold);
         this.teleportService = new TeleportService(this);
         this.questService = new QuestChainService(economy, questRepo, questProgressRepo, this);
         if (pm.getPlugin("PlaceholderAPI") != null) {

--- a/src/main/java/org/maks/fishingPlugin/service/QteService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QteService.java
@@ -31,11 +31,17 @@ public class QteService {
   private final Map<UUID, State> states = new ConcurrentHashMap<>();
   private final double chance;
   private final long durationMs;
-  private final float yawThreshold = 40f;
+  private final float yawThreshold;
 
-  public QteService(double chance, long durationMs) {
+  /**
+   * @param chance chance a QTE will be triggered when a fish bites
+   * @param durationMs how long the player has to respond
+   * @param yawThreshold minimum yaw change to register a successful swipe
+   */
+  public QteService(double chance, long durationMs, float yawThreshold) {
     this.chance = chance;
     this.durationMs = durationMs;
+    this.yawThreshold = yawThreshold;
   }
 
   /** Start a QTE with some probability when a fish bites. */

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,7 @@ database:
 qte:
   chance: 0.25
   duration_ms: 1000
+  yaw_threshold: 1.0 # minimal yaw change to register success
 
 anti_cheat:
   sample_size: 5


### PR DESCRIPTION
## Summary
- Make QTE yaw threshold configurable and default to 1 degree
- Read new `yaw_threshold` from config and pass to QteService
- Document yaw threshold in config

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f60be6664832aab40d5a840cea88c