### PR TITLE
Initialize database tables and handle missing loot errors

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -97,6 +97,18 @@ public final class FishingPlugin extends JavaPlugin {
         this.questProgressRepo = new QuestProgressRepo(ds);
         this.paramRepo = new ParamRepo(ds);
         this.profileRepo = new ProfileRepo(ds);
+        try {
+            lootRepo.init();
+            mirrorItemRepo.init();
+            questRepo.init();
+            questProgressRepo.init();
+            paramRepo.init();
+            profileRepo.init();
+        } catch (SQLException e) {
+            getLogger().severe("Failed to initialize database tables: " + e.getMessage());
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
         this.levelService = new LevelService(profileRepo, this);
         this.mirrorItemService = new MirrorItemService();
         this.rodService = new RodService(this, levelService);

--- a/src/main/java/org/maks/fishingPlugin/data/LootRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/LootRepo.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import javax.sql.DataSource;
@@ -17,6 +18,30 @@ public class LootRepo {
 
   public LootRepo(DataSource dataSource) {
     this.dataSource = dataSource;
+  }
+
+  /** Create backing table if it doesn't exist. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_item_def (" +
+        "key VARCHAR(64) PRIMARY KEY, " +
+        "category VARCHAR(32) NOT NULL, " +
+        "base_weight DOUBLE NOT NULL, " +
+        "min_rod_level INT NOT NULL, " +
+        "broadcast BOOLEAN NOT NULL, " +
+        "price_base DOUBLE NOT NULL, " +
+        "price_per_kg DOUBLE NOT NULL, " +
+        "payout_multiplier DOUBLE NOT NULL, " +
+        "quality_s_weight DOUBLE NOT NULL, " +
+        "quality_a_weight DOUBLE NOT NULL, " +
+        "quality_b_weight DOUBLE NOT NULL, " +
+        "quality_c_weight DOUBLE NOT NULL, " +
+        "min_weight_g DOUBLE NOT NULL, " +
+        "max_weight_g DOUBLE NOT NULL, " +
+        "item_base64 TEXT NOT NULL" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
   }
 
   public List<LootEntry> findAll() throws SQLException {

--- a/src/main/java/org/maks/fishingPlugin/data/MirrorItemRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/MirrorItemRepo.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import javax.sql.DataSource;
@@ -17,6 +18,19 @@ public class MirrorItemRepo {
 
   public MirrorItemRepo(DataSource dataSource) {
     this.dataSource = dataSource;
+  }
+
+  /** Create backing table if it doesn't exist. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_mirror_item (" +
+        "`key` VARCHAR(64) PRIMARY KEY, " +
+        "category VARCHAR(32) NOT NULL, " +
+        "broadcast BOOLEAN NOT NULL, " +
+        "item_base64 TEXT NOT NULL" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
   }
 
   public List<MirrorItem> findAll() throws SQLException {

--- a/src/main/java/org/maks/fishingPlugin/data/ParamRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/ParamRepo.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -15,6 +16,17 @@ public class ParamRepo {
 
   public ParamRepo(DataSource dataSource) {
     this.dataSource = dataSource;
+  }
+
+  /** Create backing table if it doesn't exist. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_param (" +
+        "`key` VARCHAR(64) PRIMARY KEY, " +
+        "value TEXT NOT NULL" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
   }
 
   public Map<String, String> findAll() throws SQLException {

--- a/src/main/java/org/maks/fishingPlugin/data/ProfileRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/ProfileRepo.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Optional;
 import java.util.UUID;
 import javax.sql.DataSource;
@@ -15,6 +16,25 @@ public class ProfileRepo {
 
   public ProfileRepo(DataSource dataSource) {
     this.dataSource = dataSource;
+  }
+
+  /** Create backing table if it doesn't exist. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_profile (" +
+        "player_uuid VARCHAR(36) PRIMARY KEY, " +
+        "rod_level INT NOT NULL, " +
+        "rod_xp BIGINT NOT NULL, " +
+        "total_catches BIGINT NOT NULL, " +
+        "total_weight_g BIGINT NOT NULL, " +
+        "largest_catch_g BIGINT NOT NULL, " +
+        "qs_earned BIGINT NOT NULL, " +
+        "last_qte_sample BLOB, " +
+        "created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, " +
+        "updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
   }
 
   public Optional<Profile> find(UUID uuid) throws SQLException {

--- a/src/main/java/org/maks/fishingPlugin/data/QuestProgressRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/QuestProgressRepo.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Optional;
 import java.util.UUID;
 import javax.sql.DataSource;
@@ -16,6 +17,18 @@ public class QuestProgressRepo {
 
   public QuestProgressRepo(DataSource dataSource) {
     this.dataSource = dataSource;
+  }
+
+  /** Create backing table if it doesn't exist. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_quests_chain_progress (" +
+        "player_uuid VARCHAR(36) PRIMARY KEY, " +
+        "stage INT NOT NULL, " +
+        "count INT NOT NULL" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
   }
 
   public Optional<QuestProgress> find(UUID uuid) throws SQLException {

--- a/src/main/java/org/maks/fishingPlugin/data/QuestRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/QuestRepo.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import javax.sql.DataSource;
@@ -16,6 +17,23 @@ public class QuestRepo {
 
   public QuestRepo(DataSource dataSource) {
     this.dataSource = dataSource;
+  }
+
+  /** Create backing table if it doesn't exist. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_quest (" +
+        "stage INT PRIMARY KEY, " +
+        "title VARCHAR(255) NOT NULL, " +
+        "lore TEXT, " +
+        "goal_type VARCHAR(32) NOT NULL, " +
+        "goal INT NOT NULL, " +
+        "reward_type VARCHAR(32) NOT NULL, " +
+        "reward DOUBLE NOT NULL, " +
+        "reward_data TEXT" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
   }
 
   public List<QuestStage> findAll() throws SQLException {

--- a/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
@@ -68,7 +68,13 @@ public class FishingListener implements Listener {
       return;
     }
     int rodLevel = levelService.getLevel(player);
-    LootEntry loot = lootService.roll(rodLevel);
+    LootEntry loot;
+    try {
+      loot = lootService.roll(rodLevel);
+    } catch (IllegalStateException e) {
+      player.sendMessage("No loot configured.");
+      return;
+    }
     Awarder.AwardResult res = awarder.give(player, loot);
     if (res.item() != null) {
       double kg = res.weightG() / 1000.0;

--- a/src/main/java/org/maks/fishingPlugin/service/RodService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/RodService.java
@@ -12,6 +12,7 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 /**
  * Handles creation, detection and updating of the custom fishing rod item.
@@ -60,7 +61,7 @@ public class RodService {
     if (filled > bars) filled = bars;
     StringBuilder sb = new StringBuilder("[");
     for (int i = 0; i < bars; i++) {
-      sb.append(i < filled ? "#" : "-");
+      sb.append(i < filled ? "█" : "░");
     }
     sb.append("] ").append(xp).append("/").append(needed);
     return sb.toString();
@@ -87,8 +88,9 @@ public class RodService {
     meta.setUnbreakable(true);
     meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_UNBREAKABLE);
     long needed = levelService.neededExp(level);
-    meta.lore(List.of(Component.text("Level: " + level),
-        Component.text(progressLine(xp, needed))));
+    meta.lore(List.of(
+        Component.text("Level: " + level, NamedTextColor.GRAY),
+        Component.text(progressLine(xp, needed), NamedTextColor.GRAY)));
     applyEnchants(meta, level);
   }
 


### PR DESCRIPTION
## Summary
- create database tables on startup for all repositories to avoid missing table errors
- guard fishing event when no loot entries are configured

## Testing
- `mvn -q package` *(fails: Could not resolve maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f6039a29c832a90a677ce9b5caf9e