### PR TITLE
Fix Component builder usage for progress bar

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/service/RodService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/RodService.java
@@ -13,6 +13,7 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.TextComponent;
 
 /**
  * Handles creation, detection and updating of the custom fishing rod item.
@@ -60,7 +61,7 @@ public class RodService {
     int filled = (int) Math.round((double) xp / needed * bars);
     if (filled > bars) filled = bars;
 
-    Component.Builder builder = Component.text().append(Component.text("[", NamedTextColor.GRAY));
+    TextComponent.Builder builder = Component.text().append(Component.text("[", NamedTextColor.GRAY));
     for (int i = 0; i < bars; i++) {
       builder.append(Component.text("█", i < filled ? NamedTextColor.GRAY : NamedTextColor.DARK_GRAY));
 


### PR DESCRIPTION
## Summary
- fix RodService by using TextComponent.Builder instead of nonexistent Component.Builder
- add missing TextComponent import

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f86052298832a95e90203b14564c1