### PR TITLE
Simplify quick sell menu and hardcode craft drops

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/gui/QuickSellMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/QuickSellMenu.java
@@ -1,48 +1,28 @@
 package org.maks.fishingPlugin.gui;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import net.kyori.adventure.text.Component;
-import org.maks.fishingPlugin.model.SellSummary;
 import org.maks.fishingPlugin.service.QuickSellService;
 
 /**
- * Inventory based quick sell menu allowing selection of fish to sell.
+ * Simple chest-style menu where players place fish to sell.
  */
 public class QuickSellMenu implements Listener {
 
   private final QuickSellService quickSellService;
-  private final Map<java.util.UUID, Set<String>> selections = new HashMap<>();
 
   public QuickSellMenu(QuickSellService quickSellService) {
     this.quickSellService = quickSellService;
-  }
-
-  private ItemStack entryItem(SellSummary.Entry e, boolean selected) {
-    ItemStack item = new ItemStack(selected ? Material.LIME_DYE : Material.GRAY_DYE);
-    ItemMeta meta = item.getItemMeta();
-    if (meta != null) {
-      meta.displayName(Component.text(e.key() + " [" + e.quality() + "]"));
-      java.util.List<Component> lore = new java.util.ArrayList<>();
-      lore.add(Component.text("Amount: " + e.amount()));
-      lore.add(Component.text("Price: " + quickSellService.currencySymbol()
-          + String.format("%.2f", e.price())));
-      meta.lore(lore);
-      item.setItemMeta(meta);
-    }
-    return item;
   }
 
   private ItemStack button(Material mat, String name) {
@@ -55,20 +35,8 @@ public class QuickSellMenu implements Listener {
     return item;
   }
 
-  private Inventory createInventory(Player player) {
-    SellSummary summary = quickSellService.summarize(player);
-    Set<String> sel = selections.computeIfAbsent(player.getUniqueId(), k -> new HashSet<>());
-    Inventory inv = Bukkit.createInventory(new Holder(summary), 54, "Quick Sell");
-    int slot = 0;
-    for (SellSummary.Entry e : summary.entries()) {
-      String gk = QuickSellService.groupKey(e.key(), e.quality());
-      boolean selected = sel.contains(gk);
-      ItemStack item = entryItem(e, selected);
-      if (slot < 45) {
-        inv.setItem(slot, item);
-      }
-      slot++;
-    }
+  private Inventory createInventory() {
+    Inventory inv = Bukkit.createInventory(new Holder(), 54, "Quick Sell");
     ItemStack filler = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
     ItemMeta fMeta = filler.getItemMeta();
     if (fMeta != null) {
@@ -84,52 +52,61 @@ public class QuickSellMenu implements Listener {
 
   /** Open the quick sell menu. */
   public void open(Player player) {
-    player.openInventory(createInventory(player));
+    player.openInventory(createInventory());
   }
 
   @EventHandler
   public void onClick(InventoryClickEvent event) {
-    if (!(event.getInventory().getHolder() instanceof Holder holder)) {
+    if (!(event.getInventory().getHolder() instanceof Holder)) {
       return;
     }
-    event.setCancelled(true);
-    Player player = (Player) event.getWhoClicked();
-    Set<String> sel = selections.computeIfAbsent(player.getUniqueId(), k -> new HashSet<>());
-
     int slot = event.getRawSlot();
     if (slot == 49) {
-      double amount = quickSellService.sellSelected(player, sel);
+      event.setCancelled(true);
+      Inventory inv = event.getInventory();
+      ItemStack[] items = new ItemStack[45];
+      for (int i = 0; i < 45; i++) {
+        items[i] = inv.getItem(i);
+      }
+      Player player = (Player) event.getWhoClicked();
+      double amount = quickSellService.sellItems(player, items);
       if (amount > 0) {
-        player.sendMessage("Sold fish for " + quickSellService.currencySymbol()
-            + String.format("%.2f", amount));
+        player.sendMessage("Sold fish for " + quickSellService.currencySymbol() + String.format("%.2f", amount));
+        for (int i = 0; i < 45; i++) {
+          inv.setItem(i, null);
+        }
       } else {
         player.sendMessage("No fish sold");
       }
-      sel.clear();
-      open(player);
       return;
     }
-    if (slot >= 0 && slot < holder.summary.entries().size() && slot < 45) {
-      SellSummary.Entry e = holder.summary.entries().get(slot);
-      String gk = QuickSellService.groupKey(e.key(), e.quality());
-      if (sel.contains(gk)) {
-        sel.remove(gk);
-      } else {
-        sel.add(gk);
+    if (slot >= 45 && slot < 54) {
+      event.setCancelled(true);
+    }
+  }
+
+  @EventHandler
+  public void onClose(InventoryCloseEvent event) {
+    if (!(event.getInventory().getHolder() instanceof Holder)) {
+      return;
+    }
+    Inventory inv = event.getInventory();
+    Player player = (Player) event.getPlayer();
+    for (int i = 0; i < 45; i++) {
+      ItemStack item = inv.getItem(i);
+      if (item != null && item.getType() != Material.AIR) {
+        java.util.Map<Integer, ItemStack> leftover = player.getInventory().addItem(item);
+        for (ItemStack drop : leftover.values()) {
+          player.getWorld().dropItem(player.getLocation(), drop);
+        }
       }
-      open(player);
     }
   }
 
   private static class Holder implements InventoryHolder {
-    final SellSummary summary;
-    Holder(SellSummary summary) {
-      this.summary = summary;
-    }
     @Override
     public Inventory getInventory() {
       return null;
     }
   }
 }
-

--- a/src/main/java/org/maks/fishingPlugin/listener/QteListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/QteListener.java
@@ -18,14 +18,14 @@ public class QteListener implements Listener {
 
   @EventHandler
   public void onMove(PlayerMoveEvent event) {
-    if (event.getFrom().getYaw() == event.getTo().getYaw()) {
-      return; // no mouse movement
+    if (event.getFrom().getBlockX() != event.getTo().getBlockX()
+        || event.getFrom().getBlockY() != event.getTo().getBlockY()
+        || event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
+      qte.fail(event.getPlayer());
+      return;
     }
-    if (event.getFrom().getX() != event.getTo().getX()
-        || event.getFrom().getY() != event.getTo().getY()
-        || event.getFrom().getZ() != event.getTo().getZ()) {
-      return; // ignore physical movement
+    if (event.getFrom().getYaw() != event.getTo().getYaw()) {
+      qte.handleLook(event.getPlayer(), event.getTo().getYaw());
     }
-    qte.handleLook(event.getPlayer(), event.getTo().getYaw());
   }
 }

--- a/src/main/java/org/maks/fishingPlugin/model/SellSummary.java
+++ b/src/main/java/org/maks/fishingPlugin/model/SellSummary.java
@@ -1,8 +1,0 @@
-package org.maks.fishingPlugin.model;
-
-import java.util.List;
-
-/** Summary of potential sale grouped by species and quality. */
-public record SellSummary(List<Entry> entries, double totalPrice) {
-    public record Entry(String key, Quality quality, int amount, double price) {}
-}

--- a/src/main/java/org/maks/fishingPlugin/service/QteService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/QteService.java
@@ -68,10 +68,19 @@ public class QteService {
       return;
     }
     float diff = toYaw - st.startYaw;
+    diff = (diff + 540) % 360 - 180; // normalize to [-180,180]
     if (st.required == Direction.LEFT && diff <= -yawThreshold) {
       st.success = true;
     } else if (st.required == Direction.RIGHT && diff >= yawThreshold) {
       st.success = true;
+    }
+  }
+
+  /** Mark current QTE as failed due to player movement. */
+  public void fail(Player player) {
+    State st = states.get(player.getUniqueId());
+    if (st != null) {
+      st.success = false;
     }
   }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,9 @@ anti_cheat:
   action: CANCEL # or REDUCE
   drop_multiplier: 0.5
 
+# Chance to receive crafting materials like algae or pearls in addition to the main catch.
+craft_drop_chance: 0.05
+
 economy:
   currency_symbol: "$"
   quicksell_tax: 0.0


### PR DESCRIPTION
## Summary
- replace selection-based quick sell GUI with simple chest menu where players place fish to sell
- add service method to sell items from the GUI and drop unsold fish back to the player
- prevent algae and pearl items from rolling as normal loot by requiring an unreachable rod level
- drop algae or pearl as a bonus item with fixed tier chances instead of as regular loot
- fail the QTE if the player moves and retract the rod immediately after a catch
- detect left/right mouse swipes during QTE by ignoring tiny position changes and normalizing yaw rotation

## Testing
- `mvn -q -e package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fa1c9b2a0832ab8570a313ce1f500