### PR TITLE
Simplify quick sell menu, hardcode craft drops, verify QTE swipe, scale fish prices, and add treasure map category

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/command/AdminRodCommand.java
+++ b/src/main/java/org/maks/fishingPlugin/command/AdminRodCommand.java
@@ -1,0 +1,34 @@
+package org.maks.fishingPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.service.RodService;
+
+/**
+ * Command for administrators to receive a special admin fishing rod.
+ */
+public class AdminRodCommand implements CommandExecutor {
+
+  private final RodService rodService;
+
+  public AdminRodCommand(RodService rodService) {
+    this.rodService = rodService;
+  }
+
+  @Override
+  public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    if (!(sender instanceof Player player)) {
+      sender.sendMessage("Only players can use this command.");
+      return true;
+    }
+    if (!player.hasPermission("fishing.admin")) {
+      player.sendMessage("You don't have permission.");
+      return true;
+    }
+    rodService.giveAdminRod(player);
+    player.sendMessage("Admin fishing rod given.");
+    return true;
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
@@ -12,6 +12,13 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.maks.fishingPlugin.service.QteService;
 import org.maks.fishingPlugin.service.QuestChainService;
 import org.maks.fishingPlugin.service.AntiCheatService;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.ChatColor;
+import org.maks.fishingPlugin.service.RodService;
 
 /**
  * Listener replacing vanilla fishing drops with custom loot.
@@ -26,10 +33,12 @@ public class FishingListener implements Listener {
   private final int requiredLevel;
   private final AntiCheatService antiCheat;
   private final double dropMultiplier;
+  private final double craftChance;
+  private final RodService rodService;
 
   public FishingListener(LootService lootService, Awarder awarder, LevelService levelService,
       QteService qteService, QuestChainService questService, int requiredLevel,
-      AntiCheatService antiCheat, double dropMultiplier) {
+      AntiCheatService antiCheat, double dropMultiplier, double craftChance, RodService rodService) {
     this.lootService = lootService;
     this.awarder = awarder;
     this.levelService = levelService;
@@ -38,6 +47,8 @@ public class FishingListener implements Listener {
     this.requiredLevel = requiredLevel;
     this.antiCheat = antiCheat;
     this.dropMultiplier = dropMultiplier;
+    this.craftChance = craftChance;
+    this.rodService = rodService;
   }
 
   @EventHandler
@@ -57,19 +68,20 @@ public class FishingListener implements Listener {
       return;
     }
     event.setCancelled(true);
-    if (!qteService.consume(player)) {
+    event.getHook().remove();
+    if (!qteService.verify(player, player.getLocation().getYaw())) {
       return;
     }
     boolean penalized = antiCheat.consumeFlag(player.getUniqueId());
     if (penalized && ThreadLocalRandom.current().nextDouble() > dropMultiplier) {
       return;
     }
-    int rodLevel = levelService.getLevel(player);
+    boolean admin = rodService.isAdminRod(player.getInventory().getItemInMainHand());
+    int rodLevel = admin ? 300 : levelService.getLevel(player);
     LootEntry loot;
     try {
-      loot = lootService.roll(rodLevel);
+      loot = admin ? lootService.rollAdmin() : lootService.roll(rodLevel);
     } catch (IllegalStateException e) {
-
       return;
     }
     Awarder.AwardResult res = awarder.give(player, loot);
@@ -77,6 +89,56 @@ public class FishingListener implements Listener {
       double kg = res.weightG() / 1000.0;
       levelService.awardCatchExp(player, loot.category(), kg);
       questService.onCatch(player);
+      maybeGiveCraft(player);
     }
+  }
+
+  private void maybeGiveCraft(Player player) {
+    if (craftChance <= 0.0) {
+      return;
+    }
+    if (ThreadLocalRandom.current().nextDouble() >= craftChance) {
+      return;
+    }
+    boolean algae = ThreadLocalRandom.current().nextBoolean();
+    double tierRoll = ThreadLocalRandom.current().nextDouble();
+    int tier = tierRoll < 0.4 ? 1 : tierRoll < 0.8 ? 2 : 3;
+    int amount = algae ? ThreadLocalRandom.current().nextInt(1, 4)
+        : ThreadLocalRandom.current().nextInt(1, 3);
+    ItemStack item = buildCraftItem(algae, tier, amount);
+    player.getInventory().addItem(item);
+  }
+
+  private ItemStack buildCraftItem(boolean algae, int tier, int amount) {
+    Material mat = algae ? Material.HORN_CORAL : Material.TURTLE_EGG;
+    String name = (algae ? "Alga" : "Shiny Pearl");
+    ChatColor color = switch (tier) {
+      case 1 -> ChatColor.BLUE;
+      case 2 -> ChatColor.DARK_PURPLE;
+      default -> ChatColor.GOLD;
+    };
+    String display = color + "[ " + roman(tier) + " ] " + name;
+    String lore = algae
+        ? ChatColor.GRAY + "" + ChatColor.ITALIC + "Basic crafting material"
+        : ChatColor.GREEN + "" + ChatColor.ITALIC + "Rare crafting material";
+    ItemStack item = new ItemStack(mat, amount);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName(display);
+      meta.setLore(java.util.List.of(lore));
+      meta.addEnchant(Enchantment.DURABILITY, 10, true);
+      meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+      meta.setUnbreakable(true);
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private String roman(int tier) {
+    return switch (tier) {
+      case 1 -> "I";
+      case 2 -> "II";
+      default -> "III";
+    };
   }
 }

--- a/src/main/java/org/maks/fishingPlugin/listener/QteListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/QteListener.java
@@ -5,9 +5,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.maks.fishingPlugin.service.QteService;
 
-/**
- * Captures mouse look changes during QTE windows.
- */
+/** Captures movement during QTE windows. */
 public class QteListener implements Listener {
 
   private final QteService qte;
@@ -18,14 +16,11 @@ public class QteListener implements Listener {
 
   @EventHandler
   public void onMove(PlayerMoveEvent event) {
-    if (event.getFrom().getYaw() == event.getTo().getYaw()) {
-      return; // no mouse movement
+    if (event.getFrom().getBlockX() != event.getTo().getBlockX()
+        || event.getFrom().getBlockY() != event.getTo().getBlockY()
+        || event.getFrom().getBlockZ() != event.getTo().getBlockZ()) {
+      qte.fail(event.getPlayer());
     }
-    if (event.getFrom().getX() != event.getTo().getX()
-        || event.getFrom().getY() != event.getTo().getY()
-        || event.getFrom().getZ() != event.getTo().getZ()) {
-      return; // ignore physical movement
-    }
-    qte.handleLook(event.getPlayer(), event.getTo().getYaw());
   }
+
 }

--- a/src/main/java/org/maks/fishingPlugin/model/Category.java
+++ b/src/main/java/org/maks/fishingPlugin/model/Category.java
@@ -7,5 +7,6 @@ public enum Category {
   FISH,
   FISHERMAN_CHEST,
   RUNE,
+  TREASURE_MAP,
   TREASURE
 }

--- a/src/main/java/org/maks/fishingPlugin/model/SellSummary.java
+++ b/src/main/java/org/maks/fishingPlugin/model/SellSummary.java
@@ -1,8 +1,0 @@
-package org.maks.fishingPlugin.model;
-
-import java.util.List;
-
-/** Summary of potential sale grouped by species and quality. */
-public record SellSummary(List<Entry> entries, double totalPrice) {
-    public record Entry(String key, Quality quality, int amount, double price) {}
-}

--- a/src/main/java/org/maks/fishingPlugin/service/Awarder.java
+++ b/src/main/java/org/maks/fishingPlugin/service/Awarder.java
@@ -85,6 +85,8 @@ public class Awarder {
     player.getInventory().addItem(item);
     if (loot.category() == Category.RUNE) {
       Bukkit.broadcastMessage("[FISHING POOL] " + player.getName() + " caught a rune!");
+    } else if (loot.category() == Category.TREASURE_MAP) {
+      Bukkit.broadcastMessage("[FISHING POOL] " + player.getName() + " found a treasure map!");
     } else if (loot.category() == Category.TREASURE) {
       Bukkit.broadcastMessage("[FISHING POOL] " + player.getName() + " found an oceanic treasure!");
     }

--- a/src/main/java/org/maks/fishingPlugin/service/LevelService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LevelService.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Logger;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.maks.fishingPlugin.data.Profile;
@@ -31,12 +32,13 @@ public class LevelService {
   private final double fishPerKg;
   private final double chestBaseXp;
   private final double runeBaseXp;
+  private final double mapBaseXp;
   private final double treasureBaseXp;
 
   public LevelService(ProfileRepo profileRepo, JavaPlugin plugin,
       double expBase, double expCoeff, double expPower,
       double fishBaseXp, double fishPerKg,
-      double chestBaseXp, double runeBaseXp, double treasureBaseXp) {
+      double chestBaseXp, double runeBaseXp, double mapBaseXp, double treasureBaseXp) {
     this.profileRepo = profileRepo;
     this.logger = plugin.getLogger();
     this.expBase = expBase;
@@ -46,6 +48,7 @@ public class LevelService {
     this.fishPerKg = fishPerKg;
     this.chestBaseXp = chestBaseXp;
     this.runeBaseXp = runeBaseXp;
+    this.mapBaseXp = mapBaseXp;
     this.treasureBaseXp = treasureBaseXp;
   }
 
@@ -149,6 +152,7 @@ public class LevelService {
       case FISH -> gain = Math.round(fishBaseXp + fishPerKg * weightKg);
       case FISHERMAN_CHEST -> gain = Math.round(chestBaseXp);
       case RUNE -> gain = Math.round(runeBaseXp);
+      case TREASURE_MAP -> gain = Math.round(mapBaseXp);
       case TREASURE -> gain = Math.round(treasureBaseXp);
       default -> gain = 0;
     }
@@ -167,6 +171,7 @@ public class LevelService {
     if (rodService != null) {
       rodService.updatePlayerRod(p, level, xp);
     }
+    p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1.0f, 1.0f);
     return level;
   }
 

--- a/src/main/java/org/maks/fishingPlugin/service/LootService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/LootService.java
@@ -91,6 +91,31 @@ public class LootService {
     return picker.pick(ThreadLocalRandom.current());
   }
 
+  /**
+   * Rolls loot for the admin rod: only non-fish categories with equal weights
+   * and ignoring level requirements.
+   */
+  public LootEntry rollAdmin() {
+    if (entries.isEmpty()) {
+      throw new IllegalStateException("No loot entries registered");
+    }
+    Map<Category, List<LootEntry>> byCat = new EnumMap<>(Category.class);
+    for (LootEntry e : entries) {
+      if (e.category() == Category.FISH) {
+        continue;
+      }
+      byCat.computeIfAbsent(e.category(), k -> new ArrayList<>()).add(e);
+    }
+    List<Category> cats = new ArrayList<>(byCat.keySet());
+    if (cats.isEmpty()) {
+      throw new IllegalStateException("No loot entries available for admin rod");
+    }
+    Category picked = cats.get(ThreadLocalRandom.current().nextInt(cats.size()));
+    WeightedPicker<LootEntry> picker =
+        new WeightedPicker<>(byCat.get(picked), LootEntry::baseWeight);
+    return picker.pick(ThreadLocalRandom.current());
+  }
+
   public LootEntry getEntry(String key) {
     return byKey.get(key);
   }
@@ -100,7 +125,7 @@ public class LootService {
    * rod level after applying category scaling and level requirements.
    */
   private double effectiveCategoryWeight(Category cat, int rodLevel) {
-    if (cat == Category.RUNE && rodLevel < 25) {
+    if ((cat == Category.RUNE || cat == Category.TREASURE_MAP) && rodLevel < 25) {
       return 0.0;
     }
     if (cat == Category.TREASURE && rodLevel < 50) {

--- a/src/main/java/org/maks/fishingPlugin/service/RodService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/RodService.java
@@ -23,6 +23,7 @@ public class RodService {
   private final NamespacedKey rodKey;
   private final NamespacedKey levelKey;
   private final NamespacedKey xpKey;
+  private final NamespacedKey adminKey;
   private final LevelService levelService;
 
   public RodService(JavaPlugin plugin, LevelService levelService) {
@@ -30,6 +31,7 @@ public class RodService {
     this.rodKey = new NamespacedKey(plugin, "fishing-rod");
     this.levelKey = new NamespacedKey(plugin, "rod-level");
     this.xpKey = new NamespacedKey(plugin, "rod-xp");
+    this.adminKey = new NamespacedKey(plugin, "admin-rod");
   }
 
   private PersistentDataContainer container(ItemMeta meta) {
@@ -44,6 +46,13 @@ public class RodService {
     return container(meta).has(rodKey, PersistentDataType.BYTE);
   }
 
+  /** Determine whether an item is the special admin fishing rod. */
+  public boolean isAdminRod(ItemStack item) {
+    if (!isRod(item)) return false;
+    ItemMeta meta = item.getItemMeta();
+    return meta != null && container(meta).has(adminKey, PersistentDataType.BYTE);
+  }
+
   /** Create a new fishing rod item with the given stats. */
   public ItemStack createRod(int level, long xp) {
     ItemStack rod = new ItemStack(Material.FISHING_ROD);
@@ -51,6 +60,18 @@ public class RodService {
     if (meta != null) {
       container(meta).set(rodKey, PersistentDataType.BYTE, (byte) 1);
       updateMeta(meta, level, xp);
+      rod.setItemMeta(meta);
+    }
+    return rod;
+  }
+
+  /** Create an admin rod starting at level 300 that bypasses drop requirements. */
+  public ItemStack createAdminRod() {
+    ItemStack rod = createRod(300, 0);
+    ItemMeta meta = rod.getItemMeta();
+    if (meta != null) {
+      container(meta).set(adminKey, PersistentDataType.BYTE, (byte) 1);
+      meta.displayName(Component.text("Admin Fishing Rod"));
       rod.setItemMeta(meta);
     }
     return rod;
@@ -118,5 +139,10 @@ public class RodService {
   /** Give a fresh rod to the player. */
   public void giveRod(Player player) {
     player.getInventory().addItem(createRod(1, 0));
+  }
+
+  /** Give the admin rod to the player. */
+  public void giveAdminRod(Player player) {
+    player.getInventory().addItem(createAdminRod());
   }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,9 @@ anti_cheat:
   action: CANCEL # or REDUCE
   drop_multiplier: 0.5
 
+# Chance to receive crafting materials like algae or pearls in addition to the main catch.
+craft_drop_chance: 0.05
+
 economy:
   currency_symbol: "$"
   quicksell_tax: 0.0
@@ -33,6 +36,7 @@ exp_gain:
   fish_per_kg: 0.5
   chest_base: 22
   rune_base: 40
+  map_base: 40
   treasure_base: 80
 
 warps:
@@ -50,9 +54,10 @@ warps:
     z: -210.5
 
 category_weights:
-  FISH: 9600
+  FISH: 9520
   FISHERMAN_CHEST: 300
   RUNE: 80
+  TREASURE_MAP: 80
   TREASURE: 8
 
 category_scaling:
@@ -63,6 +68,9 @@ category_scaling:
     mode: EXP
     beta: 0.0025
   RUNE:
+    mode: EXP
+    beta: 0.0020
+  TREASURE_MAP:
     mode: EXP
     beta: 0.0020
   TREASURE:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,6 +16,10 @@ commands:
     description: Give the fishing rod item
     usage: /fishingrod
     permission: fishing.admin
+  adminrod:
+    description: Give the admin fishing rod
+    usage: /adminrod
+    permission: fishing.admin
 permissions:
   fishing.admin:
     description: Allows editing loot and quests


### PR DESCRIPTION
## Summary
- Color quick sell success messages green/yellow for clearer feedback
- Add `/adminrod` command for an equal chest/rune/treasure rod that skips fish
- Support admin rod in loot rolling and detection
- Show QTE direction and require a swipe; wrong or no swipe cancels fishing
- Bonus algae/pearl drops now roll random stack sizes (1-3 algae or 1-2 pearls)
- Verify QTE swipe when reeling in instead of relying on left-click detection
- Always reseed default fish loot so quick sell pays about $10k per fish and $100k for pufferfish
- Scale default fish prices by weight and quality to land between roughly $1.5k and $15k
- Introduce a new Treasure Map category with rune-like odds and XP, adjusting fish weight accordingly

## Testing
- `mvn -q -e package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fa1c9b2a0832ab8570a313ce1f500