### PR TITLE
Add ownership locking to fishing rods

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
@@ -56,6 +56,12 @@ public class FishingListener implements Listener {
   @EventHandler
   public void onFish(PlayerFishEvent event) {
     Player player = event.getPlayer();
+    ItemStack rod = player.getInventory().getItemInMainHand();
+    if (rodService.isRod(rod) && !rodService.isOwner(rod, player)) {
+      event.setCancelled(true);
+      player.sendMessage("This rod is not yours.");
+      return;
+    }
     if (event.getState() == PlayerFishEvent.State.FISHING) {
       if (player.getLevel() < requiredLevel) {
         event.setCancelled(true);


### PR DESCRIPTION
## Summary
- Track rod owner via persistent metadata and lore
- Restrict fishing rod usage to the owning player

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a028952048832aa258879506405898