### PR TITLE
feat: expose fishing reward event

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/api/FishRewardEvent.java
+++ b/src/main/java/org/maks/fishingPlugin/api/FishRewardEvent.java
@@ -1,0 +1,36 @@
+package org.maks.fishingPlugin.api;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+import org.maks.fishingPlugin.model.LootEntry;
+
+/**
+ * Event fired whenever a player receives any fishing loot, including fish,
+ * runes, fisherman chests, treasure maps or treasures.
+ * Allows external plugins to react, e.g. doubling the reward item.
+ */
+public class FishRewardEvent extends Event {
+  private static final HandlerList handlers = new HandlerList();
+  private final Player player;
+  private final LootEntry loot;
+  private final ItemStack item;
+  private final double weightG;
+
+  public FishRewardEvent(Player player, LootEntry loot, ItemStack item, double weightG) {
+    this.player = player;
+    this.loot = loot;
+    this.item = item;
+    this.weightG = weightG;
+  }
+
+  public Player getPlayer() { return player; }
+  public LootEntry getLoot() { return loot; }
+  public ItemStack getItem() { return item; }
+  public double getWeightG() { return weightG; }
+
+  @Override
+  public HandlerList getHandlers() { return handlers; }
+  public static HandlerList getHandlerList() { return handlers; }
+}

--- a/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
@@ -1,9 +1,11 @@
 package org.maks.fishingPlugin.listener;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerFishEvent;
+import org.maks.fishingPlugin.api.FishRewardEvent;
 import org.maks.fishingPlugin.model.LootEntry;
 import org.maks.fishingPlugin.service.Awarder;
 import org.maks.fishingPlugin.service.LevelService;
@@ -98,6 +100,10 @@ public class FishingListener implements Listener {
       double kg = res.weightG() / 1000.0;
       levelService.awardCatchExp(player, loot.category(), kg);
       questService.onCatch(player, loot, res.weightG(), res.item());
+    }
+    Bukkit.getPluginManager().callEvent(
+        new FishRewardEvent(player, loot, res.item(), res.weightG()));
+    if (res.item() != null) {
       maybeGiveCraft(player);
     }
   }


### PR DESCRIPTION
## Summary
- add `FishRewardEvent` so external plugins can react to caught items
- fire event after awarding loot, including runes, chests, treasure maps, and treasures

## Testing
- `mvn -DskipTests package` *(fails: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a03172e7f4832ab8041be32ee0c4a3