### PR TITLE
Add quest GUI command

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -46,6 +46,7 @@ import org.maks.fishingPlugin.gui.AdminQuestEditorMenu;
 import org.maks.fishingPlugin.command.QuickSellCommand;
 import org.maks.fishingPlugin.command.GiveRodCommand;
 import org.maks.fishingPlugin.command.AdminRodCommand;
+import org.maks.fishingPlugin.command.QuestCommand;
 import net.milkbowl.vault.economy.Economy;
 
 public final class FishingPlugin extends JavaPlugin {
@@ -292,6 +293,7 @@ public final class FishingPlugin extends JavaPlugin {
         getCommand("fishsell").setExecutor(new QuickSellCommand(quickSellMenu));
         getCommand("fishingrod").setExecutor(new GiveRodCommand(rodService));
         getCommand("adminrod").setExecutor(new AdminRodCommand(rodService));
+        getCommand("fishing_quests").setExecutor(new QuestCommand(questMenu));
 
         Bukkit.getPluginManager().registerEvents(mainMenu, this);
         Bukkit.getPluginManager().registerEvents(quickSellMenu, this);

--- a/src/main/java/org/maks/fishingPlugin/command/QuestCommand.java
+++ b/src/main/java/org/maks/fishingPlugin/command/QuestCommand.java
@@ -1,0 +1,33 @@
+package org.maks.fishingPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.gui.QuestMenu;
+
+/**
+ * Command to open the quest menu.
+ */
+public class QuestCommand implements CommandExecutor {
+
+  private final QuestMenu menu;
+
+  public QuestCommand(QuestMenu menu) {
+    this.menu = menu;
+  }
+
+  @Override
+  public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    if (!(sender instanceof Player player)) {
+      sender.sendMessage("Only players can use this command.");
+      return true;
+    }
+    if (!player.hasPermission("fishing.use")) {
+      player.sendMessage("You don't have permission.");
+      return true;
+    }
+    menu.open(player);
+    return true;
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/AdminQuestEditorMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/AdminQuestEditorMenu.java
@@ -41,9 +41,14 @@ public class AdminQuestEditorMenu implements Listener {
 
   private Inventory createInventory() {
     Map<Integer, QuestStage> map = new HashMap<>();
-    Inventory inv = Bukkit.createInventory(new Holder(map), 27, "Quest Editor");
+    java.util.List<QuestStage> stages = questService.getStages();
+    int size = Math.min(54, Math.max(9, ((stages.size() + 8) / 9) * 9));
+    Inventory inv = Bukkit.createInventory(new Holder(map), size, "Quest Editor");
     int slot = 0;
-    for (QuestStage stage : questService.getStages()) {
+    for (QuestStage stage : stages) {
+      if (slot >= size) {
+        break;
+      }
       ItemStack item = new ItemStack(Material.PAPER);
       ItemMeta meta = item.getItemMeta();
       if (meta != null) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,10 +20,17 @@ commands:
     description: Give the admin fishing rod
     usage: /adminrod
     permission: fishing.admin
+  fishing_quests:
+    description: View fishing quests
+    usage: /fishing_quests
+    permission: fishing.use
 permissions:
   fishing.admin:
     description: Allows editing loot and quests
     default: op
   fishing.sell:
     description: Allows selling fish
+    default: true
+  fishing.use:
+    description: Allows accessing fishing features
     default: true


### PR DESCRIPTION
## Summary
- Add `/fishing_quests` command to open quest GUI
- Register command and permission
- Resize admin quest editor inventory to fit any number of quest stages

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0345d3534832a9f4595fabab466d1