### PR TITLE
Color fishing broadcast, limit admin rod, clarify quest objectives

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/gui/QuestMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/QuestMenu.java
@@ -27,6 +27,23 @@ public class QuestMenu implements Listener {
     this.questService = questService;
   }
 
+  private Component objectiveLine(QuestStage stage) {
+    if (!stage.lore().isEmpty()) {
+      return Component.text(stage.lore(), NamedTextColor.GRAY);
+    }
+    String text = switch (stage.goalType()) {
+      case CATCH -> "Catch " + stage.goal() + " fish";
+      case SELL -> "Earn $" + stage.goal() + " from quick selling";
+      case WEIGHT -> "Catch " + stage.goal() + " g total weight";
+      case CHEST -> "Find " + stage.goal() + " Fisherman's Chests";
+      case MAP -> "Find " + stage.goal() + " Treasure Maps";
+      case RUNE -> "Collect " + stage.goal() + " Runes";
+      case TREASURE -> "Find " + stage.goal() + " Treasures";
+      case RARE_PUFFERFISH -> "Catch " + stage.goal() + " rare pufferfish";
+    };
+    return Component.text(text, NamedTextColor.GRAY);
+  }
+
   private Inventory createInventory(Player player) {
     Inventory inv = Bukkit.createInventory(new Holder(), 54, "Quests");
     ItemStack filler = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
@@ -61,6 +78,7 @@ public class QuestMenu implements Listener {
           meta.displayName(Component.text("Quest " + (i + 1), NamedTextColor.GREEN));
           meta.lore(java.util.List.of(
               Component.text(stage.title(), NamedTextColor.GRAY),
+              objectiveLine(stage),
               Component.text("Completed", NamedTextColor.GREEN)));
           item.setItemMeta(meta);
         }
@@ -74,9 +92,7 @@ public class QuestMenu implements Listener {
           if (!stage.title().isEmpty()) {
             lore.add(Component.text(stage.title(), NamedTextColor.GRAY));
           }
-          if (!stage.lore().isEmpty()) {
-            lore.add(Component.text(stage.lore(), NamedTextColor.GRAY));
-          }
+          lore.add(objectiveLine(stage));
           lore.add(Component.text(
               "Progress: " + prog.count() + "/" + stage.goal(), NamedTextColor.YELLOW));
           if (ready) {
@@ -92,6 +108,7 @@ public class QuestMenu implements Listener {
           meta.displayName(Component.text("Quest " + (i + 1), NamedTextColor.RED));
           meta.lore(java.util.List.of(
               Component.text(stage.title(), NamedTextColor.GRAY),
+              objectiveLine(stage),
               Component.text("Locked", NamedTextColor.RED)));
           item.setItemMeta(meta);
         }

--- a/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
+++ b/src/main/java/org/maks/fishingPlugin/listener/FishingListener.java
@@ -106,6 +106,9 @@ public class FishingListener implements Listener {
     if (res.item() != null) {
       maybeGiveCraft(player);
     }
+    if (admin) {
+      rodService.convertAdminRod(player);
+    }
   }
 
 

--- a/src/main/java/org/maks/fishingPlugin/service/Awarder.java
+++ b/src/main/java/org/maks/fishingPlugin/service/Awarder.java
@@ -83,12 +83,14 @@ public class Awarder {
       item.setItemMeta(meta);
     }
     player.getInventory().addItem(item);
+    String prefix = ChatColor.YELLOW + "[FISHING POOL] "
+        + ChatColor.GREEN + player.getName() + ChatColor.YELLOW + " ";
     if (loot.category() == Category.RUNE) {
-      Bukkit.broadcastMessage("[FISHING POOL] " + player.getName() + " caught a rune!");
+      Bukkit.broadcastMessage(prefix + "caught a rune!");
     } else if (loot.category() == Category.TREASURE_MAP) {
-      Bukkit.broadcastMessage("[FISHING POOL] " + player.getName() + " found a treasure map!");
+      Bukkit.broadcastMessage(prefix + "found a treasure map!");
     } else if (loot.category() == Category.TREASURE) {
-      Bukkit.broadcastMessage("[FISHING POOL] " + player.getName() + " found an oceanic treasure!");
+      Bukkit.broadcastMessage(prefix + "found an oceanic treasure!");
     }
     return new AwardResult(weight, item);
   }

--- a/src/main/java/org/maks/fishingPlugin/service/RodService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/RodService.java
@@ -183,6 +183,21 @@ public class RodService {
     player.getInventory().addItem(createAdminRod(player));
   }
 
+  /** Convert an admin rod in the player's main hand into a regular rod. */
+  public void convertAdminRod(Player player) {
+    ItemStack rod = player.getInventory().getItemInMainHand();
+    if (!isAdminRod(rod)) {
+      return;
+    }
+    ItemMeta meta = rod.getItemMeta();
+    if (meta != null) {
+      container(meta).remove(adminKey);
+      rod.setItemMeta(meta);
+      player.getInventory().setItemInMainHand(rod);
+    }
+    updatePlayerRod(player, levelService.getLevel(player), levelService.getXp(player));
+  }
+
   /**
    * Check if the given player is the owner of the rod item.
    * If the rod has no owner yet, it becomes owned by the player.


### PR DESCRIPTION
## Summary
- Add green-yellow styling to rune, map, and treasure catch broadcasts
- Convert admin fishing rods to normal player rods after one use
- Display quest objectives so players know what to do

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0600d7410832abe05b7152c378e6a