### PR TITLE
Fix quest reward editor

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/util/ItemSerialization.java
+++ b/src/main/java/org/maks/fishingPlugin/util/ItemSerialization.java
@@ -31,6 +31,25 @@ public final class ItemSerialization {
   }
 
   /**
+   * Serializes an array of ItemStacks into a Base64 string.
+   *
+   * @param items the items to serialize
+   * @return base64 representation
+   */
+  public static String toBase64(ItemStack[] items) {
+    try (var baos = new ByteArrayOutputStream();
+         var oos = new BukkitObjectOutputStream(baos)) {
+      oos.writeInt(items.length);
+      for (ItemStack item : items) {
+        oos.writeObject(item);
+      }
+      return Base64.getEncoder().encodeToString(baos.toByteArray());
+    } catch (IOException e) {
+      throw new RuntimeException("Could not serialize items", e);
+    }
+  }
+
+  /**
    * Deserializes an ItemStack from its Base64 representation.
    *
    * @param b64 base64 string
@@ -43,6 +62,32 @@ public final class ItemSerialization {
       return (ItemStack) ois.readObject();
     } catch (IOException | ClassNotFoundException e) {
       throw new RuntimeException("Could not deserialize item", e);
+    }
+  }
+
+  /**
+   * Deserializes an array of ItemStacks from its Base64 representation.
+   * Falls back to a single item if older data is encountered.
+   *
+   * @param b64 base64 string
+   * @return array of deserialized items
+   */
+  public static ItemStack[] fromBase64List(String b64) {
+    if (b64 == null || b64.isEmpty()) {
+      return new ItemStack[0];
+    }
+    byte[] data = Base64.getDecoder().decode(b64);
+    try (var bais = new ByteArrayInputStream(data);
+         var ois = new BukkitObjectInputStream(bais)) {
+      int len = ois.readInt();
+      ItemStack[] items = new ItemStack[len];
+      for (int i = 0; i < len; i++) {
+        items[i] = (ItemStack) ois.readObject();
+      }
+      return items;
+    } catch (IOException | ClassNotFoundException e) {
+      // Fall back to single item format
+      return new ItemStack[] { fromBase64(b64) };
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow editing multiple reward items by storing arrays of ItemStacks
- serialize and deserialize item arrays for quest rewards
- grant all stored reward items to players, dropping extras if inventory is full

## Testing
- `mvn -q -e -ntp test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a07d8c6244832a833900f37b128b9c