### PR TITLE
Add guide item and debug logging to Pirate King GUI

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/command/PirateKingCommand.java
+++ b/src/main/java/org/maks/fishingPlugin/command/PirateKingCommand.java
@@ -1,0 +1,33 @@
+package org.maks.fishingPlugin.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.maks.fishingPlugin.gui.PirateKingMenu;
+
+/**
+ * Command handler for the Pirate King bounty system.
+ */
+public class PirateKingCommand implements CommandExecutor {
+
+  private final PirateKingMenu menu;
+
+  public PirateKingCommand(PirateKingMenu menu) {
+    this.menu = menu;
+  }
+
+  @Override
+  public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    if (!(sender instanceof Player player)) {
+      sender.sendMessage("Only players may use this command.");
+      return true;
+    }
+    if (!player.hasPermission("fishing.pirateking")) {
+      player.sendMessage("You don't have permission.");
+      return true;
+    }
+    menu.open(player);
+    return true;
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/data/LairLockRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/LairLockRepo.java
@@ -1,0 +1,85 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.maks.fishingPlugin.service.TreasureMapService.Lair;
+
+/** Repository for lair locks ensuring single occupant per lair. */
+public class LairLockRepo {
+  public record Lock(Lair lair, UUID playerUuid, UUID mapId, long startedAt) {}
+
+  private final DataSource dataSource;
+
+  public LairLockRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  /** Create table if absent. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_lair_lock (" +
+        "lair VARCHAR(16) PRIMARY KEY, " +
+        "player_uuid VARCHAR(36) NOT NULL, " +
+        "map_id VARCHAR(36) NOT NULL, " +
+        "started_at BIGINT NOT NULL" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
+  }
+
+  /** Attempt to lock a lair, returning false if already occupied. */
+  public boolean tryLock(Lair lair, UUID player, UUID mapId) throws SQLException {
+    String sql = "INSERT INTO fishing_lair_lock(lair,player_uuid,map_id,started_at) VALUES(?,?,?,?)";
+    try (Connection con = dataSource.getConnection(); PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, lair.name());
+      ps.setString(2, player.toString());
+      ps.setString(3, mapId.toString());
+      ps.setLong(4, System.currentTimeMillis());
+      ps.executeUpdate();
+      return true;
+    } catch (SQLException e) {
+      return false; // assume duplicate key
+    }
+  }
+
+  /** Release a lair lock. */
+  public void release(Lair lair) throws SQLException {
+    String sql = "DELETE FROM fishing_lair_lock WHERE lair=?";
+    try (Connection con = dataSource.getConnection(); PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, lair.name());
+      ps.executeUpdate();
+    }
+  }
+
+  /** Remove locks older than cutoffMillis epoch. */
+  public int cleanupOlderThan(long cutoffMillis) throws SQLException {
+    String sql = "DELETE FROM fishing_lair_lock WHERE started_at < ?";
+    try (Connection con = dataSource.getConnection(); PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setLong(1, cutoffMillis);
+      return ps.executeUpdate();
+    }
+  }
+
+  /** Load all current locks. */
+  public List<Lock> findAll() throws SQLException {
+    String sql = "SELECT lair, player_uuid, map_id, started_at FROM fishing_lair_lock";
+    try (Connection con = dataSource.getConnection(); PreparedStatement ps = con.prepareStatement(sql); ResultSet rs = ps.executeQuery()) {
+      List<Lock> list = new ArrayList<>();
+      while (rs.next()) {
+        Lair lair = Lair.valueOf(rs.getString(1));
+        UUID player = UUID.fromString(rs.getString(2));
+        UUID map = UUID.fromString(rs.getString(3));
+        long started = rs.getLong(4);
+        list.add(new Lock(lair, player, map, started));
+      }
+      return list;
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/data/TreasureMapRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/TreasureMapRepo.java
@@ -1,0 +1,48 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.maks.fishingPlugin.service.TreasureMapService.MapState;
+import org.maks.fishingPlugin.service.TreasureMapService.Lair;
+
+/** Repository for persisting treasure map states. */
+public class TreasureMapRepo {
+  private final DataSource dataSource;
+
+  public TreasureMapRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  /** Create backing table if absent. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_treasure_map (" +
+        "map_id VARCHAR(36) PRIMARY KEY, " +
+        "state VARCHAR(16) NOT NULL, " +
+        "lair VARCHAR(16) NULL, " +
+        "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
+  }
+
+  /** Insert or update a map entry. */
+  public void upsert(UUID id, MapState state, Lair lair) throws SQLException {
+    String sql = "INSERT INTO fishing_treasure_map(map_id,state,lair) VALUES(?,?,?) " +
+        "ON DUPLICATE KEY UPDATE state=VALUES(state), lair=VALUES(lair)";
+    try (Connection con = dataSource.getConnection(); PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, id.toString());
+      ps.setString(2, state.name());
+      if (lair != null) {
+        ps.setString(3, lair.name());
+      } else {
+        ps.setNull(3, java.sql.Types.VARCHAR);
+      }
+      ps.executeUpdate();
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/PirateKingMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/PirateKingMenu.java
@@ -1,0 +1,341 @@
+package org.maks.fishingPlugin.gui;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.fishingPlugin.service.BountyService;
+import org.maks.fishingPlugin.service.TreasureMapService;
+import java.util.List;
+
+/**
+ * Menu for identifying treasure maps with the Pirate King.
+ */
+public class PirateKingMenu implements Listener {
+
+  private final JavaPlugin plugin;
+  private final TreasureMapService mapService;
+  private final BountyService bountyService;
+  private final String btnIdentify;
+  private final String btnConfirm;
+  private final String btnDiscard;
+  private final String btnOccupied;
+  private final String msgInsertedIdentified;
+
+  public PirateKingMenu(JavaPlugin plugin, TreasureMapService mapService, BountyService bountyService) {
+    this.plugin = plugin;
+    this.mapService = mapService;
+    this.bountyService = bountyService;
+    var sec = plugin.getConfig().getConfigurationSection("treasure_maps.buttons");
+    this.btnIdentify = sec != null ? sec.getString("identify", "Identify") : "Identify";
+    this.btnConfirm = sec != null ? sec.getString("confirm_bounty", "Confirm Bounty") : "Confirm Bounty";
+    this.btnDiscard = sec != null ? sec.getString("discard", "Discard") : "Discard";
+    this.btnOccupied = sec != null ? sec.getString("occupied", "Occupied") : "Occupied";
+    this.msgInsertedIdentified =
+        plugin.getConfig().getString("treasure_maps.messages.inserted_identified", "");
+  }
+
+  private void debugItem(ItemStack item, String context) {
+    if (item == null) {
+      plugin.getLogger().info("[PirateKingMenu] " + context + " item=null");
+      return;
+    }
+    var state = mapService.getState(item);
+    var lair = mapService.getLair(item);
+    var id = mapService.getId(item);
+    ItemMeta meta = item.getItemMeta();
+    String name = meta != null && meta.hasDisplayName() ? meta.getDisplayName() : "null";
+    List<String> lore = meta != null ? meta.getLore() : null;
+    boolean unbreakable = meta != null && meta.isUnbreakable();
+    plugin
+        .getLogger()
+        .info(
+            "[PirateKingMenu] "
+                + context
+                + " type="
+                + item.getType()
+                + " name="
+                + name
+                + " lore="
+                + lore
+                + " unbreakable="
+                + unbreakable
+                + " state="
+                + state
+                + " lair="
+                + lair
+                + " id="
+                + id);
+  }
+
+  private void debugRejection(ItemStack item, String reason) {
+    debugItem(item, "rejected-cursor");
+    plugin
+        .getLogger()
+        .info(
+            "[PirateKingMenu] reason="
+                + reason
+                + " required-name="
+                + mapService.debugUnidentifiedName()
+                + " required-lore="
+                + mapService.debugUnidentifiedLore()
+                + " required-nbt=[map_state, map_id]");
+  }
+
+  /** Open the Pirate King menu for a player. */
+  public void open(Player player) {
+    Inventory inv = createInventory();
+    player.openInventory(inv);
+  }
+
+  private String color(String s) {
+    return ChatColor.translateAlternateColorCodes('&', s);
+  }
+
+  private ItemStack filler() {
+    ItemStack item = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName(" ");
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack identifyButton() {
+    ItemStack item = new ItemStack(Material.EMERALD);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      String name = btnIdentify.replace("${cost}", mapService.currencySymbol() + mapService.identifyCost());
+      meta.setDisplayName(color(name));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack confirmButton() {
+    ItemStack item = new ItemStack(Material.LIME_DYE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName(color(btnConfirm));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack discardButton() {
+    ItemStack item = new ItemStack(Material.BARRIER);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName(color(btnDiscard));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack occupiedButton() {
+    ItemStack item = new ItemStack(Material.GRAY_DYE);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName(color(btnOccupied));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private ItemStack guideItem() {
+    ItemStack item = new ItemStack(Material.PAPER);
+    ItemMeta meta = item.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName(color("&eHow Treasure Maps Work"));
+      meta.setLore(
+          List.of(
+              color("&7Place a map in the center slot"),
+              color("&7Use left button to identify or confirm"),
+              color("&7Use right button to discard")));
+      item.setItemMeta(meta);
+    }
+    return item;
+  }
+
+  private Inventory createInventory() {
+    Inventory inv = Bukkit.createInventory(new Holder(), 27, "Pirate King");
+    ItemStack fill = filler();
+    for (int i = 0; i < 27; i++) inv.setItem(i, fill);
+    inv.setItem(13, null);
+    inv.setItem(26, guideItem());
+    return inv;
+  }
+
+  private void refresh(Player player, Inventory inv) {
+    ItemStack fill = filler();
+    inv.setItem(11, fill);
+    inv.setItem(15, fill);
+    ItemStack map = inv.getItem(13);
+    debugItem(map, "refresh-slot13");
+    if (map == null || map.getType() == Material.AIR) {
+      return;
+    }
+    // prevent stacking or foreign items slipping in
+    if (!mapService.isUnidentified(map)
+        && !mapService.isIdentified(map)
+        && !mapService.isAsh(map)) {
+      inv.setItem(13, null);
+      var leftover = player.getInventory().addItem(map);
+      for (ItemStack drop : leftover.values()) {
+        player.getWorld().dropItem(player.getLocation(), drop);
+      }
+      return;
+    }
+    if (map.getAmount() > 1) {
+      inv.setItem(13, null);
+      var leftover = player.getInventory().addItem(map);
+      for (ItemStack drop : leftover.values()) {
+        player.getWorld().dropItem(player.getLocation(), drop);
+      }
+      return;
+    }
+    if (mapService.isAsh(map)) {
+      inv.setItem(13, null);
+      var leftover = player.getInventory().addItem(map);
+      for (ItemStack drop : leftover.values()) {
+        player.getWorld().dropItem(player.getLocation(), drop);
+      }
+      player.sendMessage(bountyService.ashMessage());
+      return;
+    }
+    if (mapService.isUnidentified(map)) {
+      inv.setItem(11, identifyButton());
+    } else if (mapService.isIdentified(map)) {
+      var lair = mapService.getLair(map);
+      if (lair != null && bountyService.isOccupied(lair)) {
+        inv.setItem(11, occupiedButton());
+      } else {
+        inv.setItem(11, confirmButton());
+      }
+      inv.setItem(15, discardButton());
+      if (!msgInsertedIdentified.isEmpty()) {
+        player.sendMessage(color(msgInsertedIdentified));
+      }
+    }
+  }
+
+  @EventHandler
+  public void onClick(InventoryClickEvent event) {
+    if (!(event.getInventory().getHolder() instanceof Holder)) return;
+    Inventory inv = event.getInventory();
+    Player player = (Player) event.getWhoClicked();
+    int slot = event.getRawSlot();
+
+    // disallow shift-clicking to avoid bypassing slot checks
+    if (event.isShiftClick()) {
+      event.setCancelled(true);
+      return;
+    }
+
+    if (slot == 11) {
+      event.setCancelled(true);
+      ItemStack map = inv.getItem(13);
+      if (map != null && mapService.isUnidentified(map)) {
+        mapService.identify(player, map);
+      } else if (map != null && mapService.isIdentified(map)) {
+        if (bountyService.confirm(player, map)) {
+          inv.setItem(13, null);
+        }
+      }
+      Bukkit.getScheduler().runTask(plugin, () -> refresh(player, inv));
+      return;
+    }
+
+    if (slot == 15) {
+      event.setCancelled(true);
+      ItemStack map = inv.getItem(13);
+      if (map != null && mapService.isIdentified(map)) {
+        inv.setItem(13, null);
+        bountyService.discard(player, map);
+      }
+      Bukkit.getScheduler().runTask(plugin, () -> refresh(player, inv));
+      return;
+    }
+
+    // clicks in player inventory are allowed
+    if (slot >= inv.getSize()) {
+      return;
+    }
+
+    // only slot 13 accepts maps
+    if (slot != 13) {
+      event.setCancelled(true);
+      return;
+    }
+
+    ItemStack cursor = event.getCursor();
+    ItemStack current = inv.getItem(13);
+    if (cursor != null && cursor.getType() != Material.AIR) {
+      debugItem(cursor, "cursor-attempt");
+    }
+
+    // placing item into slot 13
+    if (cursor != null && cursor.getType() != Material.AIR) {
+      if (cursor.getAmount() != 1) {
+        event.setCancelled(true);
+        debugRejection(cursor, "amount=" + cursor.getAmount());
+        return;
+      }
+      if (!mapService.isUnidentified(cursor)
+          && !mapService.isIdentified(cursor)
+          && !mapService.isAsh(cursor)) {
+        var state = mapService.getState(cursor);
+        String reason = state == null ? "missing map_state" : "state=" + state;
+        event.setCancelled(true);
+        debugRejection(cursor, reason);
+        return;
+      }
+      if (current != null && current.getType() != Material.AIR) {
+        event.setCancelled(true);
+        return;
+      }
+    }
+
+    // picking up existing item is fine; just refresh afterwards
+    Bukkit.getScheduler().runTask(plugin, () -> refresh(player, inv));
+  }
+
+  @EventHandler
+  public void onDrag(org.bukkit.event.inventory.InventoryDragEvent event) {
+    if (event.getInventory().getHolder() instanceof Holder) {
+      event.setCancelled(true);
+    }
+  }
+
+  @EventHandler
+  public void onClose(InventoryCloseEvent event) {
+    if (!(event.getInventory().getHolder() instanceof Holder)) return;
+    Inventory inv = event.getInventory();
+    ItemStack item = inv.getItem(13);
+    if (item != null && item.getType() != Material.AIR) {
+      debugItem(item, "close-return");
+      Player player = (Player) event.getPlayer();
+      var leftover = player.getInventory().addItem(item);
+      for (ItemStack drop : leftover.values()) {
+        player.getWorld().dropItem(player.getLocation(), drop);
+      }
+    }
+  }
+
+  private static class Holder implements InventoryHolder {
+    @Override
+    public Inventory getInventory() {
+      return null;
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/BountyService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/BountyService.java
@@ -1,0 +1,281 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
+import org.bukkit.entity.Player;
+import org.bukkit.Sound;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Handles bounty confirmations and lair instances.
+ */
+public class BountyService implements Listener {
+
+  public record SpawnSpec(int count, List<String> bossPool, String cmdTemplate, int delayTicks) {}
+  public record LairSpec(String warp, int timeLimitSec, SpawnSpec spawn) {}
+
+  private final JavaPlugin plugin;
+  private final TeleportService teleportService;
+  private final TreasureMapService mapService;
+  private final org.maks.fishingPlugin.data.LairLockRepo lockRepo;
+  private final Map<TreasureMapService.Lair, LairSpec> lairSpecs = new EnumMap<>(TreasureMapService.Lair.class);
+  private final Map<TreasureMapService.Lair, UUID> occupied = new EnumMap<>(TreasureMapService.Lair.class);
+  private final Map<UUID, TreasureMapService.Lair> playerLair = new HashMap<>();
+  private final Map<UUID, BossBar> bars = new HashMap<>();
+  private final Map<UUID, Integer> barTasks = new HashMap<>();
+  private final Map<UUID, Integer> timeoutTasks = new HashMap<>();
+  private final Random random = new Random();
+
+  private final String msgConfirmStart;
+  private final String msgDiscard;
+  private final String msgLairOccupied;
+  private final String msgTimeout;
+  private final String msgDeath;
+  private final String msgAshCannotUse;
+  private final String msgWarpFailed;
+  private final String msgLairReleased;
+  private final String titleStart;
+  private final String titleStartSub;
+  private final String titleTimeout;
+  private final String titleTimeoutSub;
+  private final String titleDeath;
+  private final String titleDeathSub;
+  private final Sound confirmSound;
+
+  public BountyService(JavaPlugin plugin, TeleportService teleportService, TreasureMapService mapService,
+      org.maks.fishingPlugin.data.LairLockRepo lockRepo) {
+    this.plugin = plugin;
+    this.teleportService = teleportService;
+    this.mapService = mapService;
+    this.lockRepo = lockRepo;
+
+    var lairSec = plugin.getConfig().getConfigurationSection("treasure_maps.lairs");
+    if (lairSec != null) {
+      for (String key : lairSec.getKeys(false)) {
+        try {
+          TreasureMapService.Lair lair = TreasureMapService.Lair.valueOf(key.toUpperCase());
+          String warp = lairSec.getString(key + ".warp", "");
+          int limit = lairSec.getInt(key + ".time_limit_seconds", 600);
+          var spawnSec = lairSec.getConfigurationSection(key + ".spawn");
+          int count = spawnSec != null ? spawnSec.getInt("count", 1) : 1;
+          List<String> pool = spawnSec != null ? spawnSec.getStringList("boss_pool") : List.of();
+          String cmd = spawnSec != null ? spawnSec.getString("spawn_cmd_template", "") : "";
+          int delay = spawnSec != null ? spawnSec.getInt("spawn_delay_ticks", 20) : 20;
+          lairSpecs.put(lair, new LairSpec(warp, limit, new SpawnSpec(count, pool, cmd, delay)));
+        } catch (IllegalArgumentException ignored) {
+        }
+      }
+    }
+    var msgSec = plugin.getConfig().getConfigurationSection("treasure_maps.messages");
+    this.msgConfirmStart = msgSec != null ? msgSec.getString("confirm_start", "") : "";
+    this.msgDiscard = msgSec != null ? msgSec.getString("discard", "") : "";
+    this.msgLairOccupied = msgSec != null ? msgSec.getString("lair_occupied", "") : "";
+    this.msgTimeout = msgSec != null ? msgSec.getString("timeout", "") : "";
+    this.msgDeath = msgSec != null ? msgSec.getString("death", "") : "";
+    this.msgAshCannotUse = msgSec != null ? msgSec.getString("ash_cannot_use", "") : "";
+    this.msgWarpFailed = msgSec != null ? msgSec.getString("warp_failed", "") : "";
+    this.msgLairReleased = msgSec != null ? msgSec.getString("lair_released", "") : "";
+
+    var titleSec = plugin.getConfig().getConfigurationSection("treasure_maps.titles");
+    this.titleStart = titleSec != null ? titleSec.getString("start_title", "") : "";
+    this.titleStartSub = titleSec != null ? titleSec.getString("start_subtitle", "") : "";
+    this.titleTimeout = titleSec != null ? titleSec.getString("timeout_title", "") : "";
+    this.titleTimeoutSub = titleSec != null ? titleSec.getString("timeout_subtitle", "") : "";
+    this.titleDeath = titleSec != null ? titleSec.getString("death_title", "") : "";
+    this.titleDeathSub = titleSec != null ? titleSec.getString("death_subtitle", "") : "";
+
+    var effSec = plugin.getConfig().getConfigurationSection("treasure_maps.effects");
+    this.confirmSound = parseSound(effSec != null ? effSec.getString("on_confirm_sound") : null);
+
+    try {
+      long cutoff = System.currentTimeMillis() - 15 * 60_000L;
+      lockRepo.cleanupOlderThan(cutoff);
+      for (var lock : lockRepo.findAll()) {
+        occupied.put(lock.lair(), lock.playerUuid());
+        playerLair.put(lock.playerUuid(), lock.lair());
+      }
+    } catch (Exception e) {
+      plugin.getLogger().warning("Failed to load lair locks: " + e.getMessage());
+    }
+  }
+
+  private String color(String s) {
+    return ChatColor.translateAlternateColorCodes('&', s);
+  }
+
+  private Sound parseSound(String name) {
+    if (name == null || name.isEmpty()) return null;
+    try {
+      return Sound.valueOf(name);
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+  }
+
+  public String ashMessage() {
+    return color(msgAshCannotUse);
+  }
+
+  public boolean isOccupied(TreasureMapService.Lair lair) {
+    return occupied.containsKey(lair);
+  }
+
+  public void discard(Player player, ItemStack map) {
+    player.closeInventory();
+    var leftovers = player.getInventory().addItem(map);
+    for (ItemStack drop : leftovers.values()) {
+      player.getWorld().dropItem(player.getLocation(), drop);
+    }
+    player.sendMessage(color(msgDiscard));
+  }
+
+  public boolean confirm(Player player, ItemStack map) {
+    TreasureMapService.Lair lair = mapService.getLair(map);
+    if (lair == null) {
+      return false;
+    }
+    UUID mapId = mapService.getId(map);
+    if (mapId == null) {
+      return false;
+    }
+    if (!lockAttempt(lair, player.getUniqueId(), mapId)) {
+      player.sendMessage(color(msgLairOccupied));
+      return false;
+    }
+    LairSpec spec = lairSpecs.get(lair);
+    if (spec == null) {
+      freeLair(lair);
+      return false;
+    }
+    occupied.put(lair, player.getUniqueId());
+    playerLair.put(player.getUniqueId(), lair);
+    mapService.markSpent(map);
+    player.closeInventory();
+    if (!teleportService.teleport(spec.warp(), player)) {
+      freeLair(lair);
+      playerLair.remove(player.getUniqueId());
+      player.sendMessage(color(msgWarpFailed));
+      return false;
+    }
+    String lairName = mapService.lairDisplay(lair);
+    player.sendMessage(color(msgConfirmStart.replace("{lair}", lairName)));
+    if (confirmSound != null) {
+      player.playSound(player.getLocation(), confirmSound, 1f, 1f);
+    }
+    player.sendTitle(color(titleStart.replace("{lair}", lairName)),
+        color(titleStartSub.replace("{lair}", lairName)), 10, 60, 10);
+
+    int time = spec.timeLimitSec();
+    String initTime = String.format("%d:%02d", time / 60, time % 60);
+    BossBar bar = Bukkit.createBossBar(color(lairName + " - " + initTime), BarColor.RED, BarStyle.SOLID);
+    bar.addPlayer(player);
+    bars.put(player.getUniqueId(), bar);
+    final int[] remaining = {time};
+    int barTask = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+      remaining[0]--;
+      double prog = remaining[0] / (double) time;
+      bar.setProgress(Math.max(0, prog));
+      bar.setTitle(color(String.format("%s - %d:%02d", lairName, remaining[0] / 60, remaining[0] % 60)));
+      if (remaining[0] <= 0) {
+        bar.removeAll();
+      }
+    }, 20L, 20L);
+    barTasks.put(player.getUniqueId(), barTask);
+    int timeoutTask = Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> timeout(player.getUniqueId()), time * 20L);
+    timeoutTasks.put(player.getUniqueId(), timeoutTask);
+    Bukkit.getScheduler().runTaskLater(plugin, () -> spawnBosses(player, spec.spawn()), spec.spawn().delayTicks());
+    return true;
+  }
+
+  private boolean lockAttempt(TreasureMapService.Lair lair, UUID player, UUID mapId) {
+    try {
+      return lockRepo.tryLock(lair, player, mapId);
+    } catch (Exception e) {
+      plugin.getLogger().warning("Failed to lock lair: " + e.getMessage());
+      return false;
+    }
+  }
+
+  private void freeLair(TreasureMapService.Lair lair) {
+    occupied.remove(lair);
+    try {
+      lockRepo.release(lair);
+    } catch (Exception e) {
+      plugin.getLogger().warning("Failed to release lair: " + e.getMessage());
+    }
+    if (!msgLairReleased.isEmpty()) {
+      Bukkit.broadcastMessage(color(msgLairReleased.replace("{lair}", mapService.lairDisplay(lair))));
+    }
+  }
+
+  private void cancelTasks(UUID playerId) {
+    Integer bt = barTasks.remove(playerId);
+    if (bt != null) Bukkit.getScheduler().cancelTask(bt);
+    Integer tt = timeoutTasks.remove(playerId);
+    if (tt != null) Bukkit.getScheduler().cancelTask(tt);
+    BossBar bar = bars.remove(playerId);
+    if (bar != null) bar.removeAll();
+  }
+
+  private void spawnBosses(Player player, SpawnSpec spawn) {
+    Location loc = player.getLocation();
+    for (int i = 0; i < spawn.count(); i++) {
+      if (spawn.bossPool().isEmpty()) break;
+      String mob = spawn.bossPool().get(random.nextInt(spawn.bossPool().size()));
+      String cmd = spawn.cmdTemplate()
+          .replace("{mob}", mob)
+          .replace("{world}", loc.getWorld().getName())
+          .replace("{x}", String.valueOf(loc.getBlockX()))
+          .replace("{y}", String.valueOf(loc.getBlockY()))
+          .replace("{z}", String.valueOf(loc.getBlockZ()));
+      Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
+    }
+  }
+
+  private void timeout(UUID playerId) {
+    release(playerId, msgTimeout, titleTimeout, titleTimeoutSub);
+  }
+
+  private void release(UUID playerId, String message, String title, String subtitle) {
+    TreasureMapService.Lair lair = playerLair.remove(playerId);
+    if (lair != null) {
+      freeLair(lair);
+      cancelTasks(playerId);
+      Player p = Bukkit.getPlayer(playerId);
+      if (p != null && p.isOnline()) {
+        p.teleport(p.getWorld().getSpawnLocation());
+        p.sendMessage(color(message));
+        if (title != null && subtitle != null) {
+          String lairName = mapService.lairDisplay(lair);
+          p.sendTitle(color(title.replace("{lair}", lairName)),
+              color(subtitle.replace("{lair}", lairName)), 10, 60, 10);
+        }
+      }
+    }
+  }
+
+  @EventHandler
+  public void onQuit(PlayerQuitEvent e) {
+    release(e.getPlayer().getUniqueId(), msgTimeout, null, null);
+  }
+
+  @EventHandler
+  public void onDeath(PlayerDeathEvent e) {
+    release(e.getEntity().getUniqueId(), msgDeath, titleDeath, titleDeathSub);
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/TreasureMapService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/TreasureMapService.java
@@ -1,0 +1,340 @@
+package org.maks.fishingPlugin.service;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+
+/**
+ * Handles treasure map identification and metadata.
+ */
+public class TreasureMapService {
+
+  public enum MapState { UNIDENTIFIED, IDENTIFIED, ASH, SPENT }
+
+  public enum Lair { INFERNAL, HELL, BLOOD, KRAKEN }
+
+  private record Weighted(Lair lair, double weight) {}
+
+  private final Economy economy;
+  private final NamespacedKey idKey;
+  private final NamespacedKey stateKey;
+  private final NamespacedKey lairKey;
+  private final double identifyCost;
+  private final String currencySymbol;
+  private final List<Weighted> weights = new ArrayList<>();
+  private double totalWeight;
+  private final String unidentifiedName;
+  private final List<String> unidentifiedLore;
+  private final String ashName;
+  private final List<String> ashLore;
+  private final String identifiedNameFormat;
+  private final String identifiedLoreHeader;
+  private final String identifiedTradeNote;
+  private final Map<Lair, List<String>> lairLore = new EnumMap<>(Lair.class);
+  private final String msgNotEnoughMoney;
+  private final String msgIdentifySuccess;
+  private final String msgIdentifyEmpty;
+  private final Sound identifySuccessSound;
+  private final Sound identifyEmptySound;
+  private final Random random = new Random();
+  private final org.maks.fishingPlugin.data.TreasureMapRepo repo;
+
+  public TreasureMapService(JavaPlugin plugin, Economy economy, org.maks.fishingPlugin.data.TreasureMapRepo repo) {
+    this.economy = economy;
+    this.repo = repo;
+    this.idKey = new NamespacedKey(plugin, "map_id");
+    this.stateKey = new NamespacedKey(plugin, "map_state");
+    this.lairKey = new NamespacedKey(plugin, "map_lair");
+    ConfigurationSection sec = plugin.getConfig().getConfigurationSection("treasure_maps");
+    if (sec == null) {
+      throw new IllegalStateException("treasure_maps section missing");
+    }
+    this.identifyCost = sec.getDouble("identify_cost", 0);
+    this.currencySymbol = plugin.getConfig().getString("economy.currency_symbol", "$");
+
+    ConfigurationSection outcomes = sec.getConfigurationSection("outcomes");
+    if (outcomes != null) {
+      for (String key : outcomes.getKeys(false)) {
+        double w = outcomes.getDouble(key);
+        if (key.equalsIgnoreCase("EMPTY")) {
+          weights.add(new Weighted(null, w));
+        } else {
+          try {
+            Lair l = Lair.valueOf(key.toUpperCase());
+            weights.add(new Weighted(l, w));
+          } catch (IllegalArgumentException ignored) {
+          }
+        }
+        totalWeight += w;
+      }
+    }
+
+    ConfigurationSection items = sec.getConfigurationSection("items");
+    this.unidentifiedName = items != null ? items.getString("unidentified_name", "Unidentified Map") : "Unidentified Map";
+    this.unidentifiedLore = items != null ? items.getStringList("unidentified_lore") : List.of();
+    this.ashName = items != null ? items.getString("ash_name", "Ash Map") : "Ash Map";
+    this.ashLore = items != null ? items.getStringList("ash_lore") : List.of();
+    this.identifiedNameFormat = items != null ? items.getString("identified_name_format", "{lair} Map") : "{lair} Map";
+    this.identifiedLoreHeader = items != null ? items.getString("identified_lore_header", "-") : "-";
+    this.identifiedTradeNote = items != null ? items.getString("identified_trade_note", "") : "";
+
+    ConfigurationSection lairSec = sec.getConfigurationSection("lairs");
+    if (lairSec != null) {
+      for (String key : lairSec.getKeys(false)) {
+        try {
+          Lair l = Lair.valueOf(key.toUpperCase());
+          lairLore.put(l, lairSec.getStringList(key + ".lore_lines"));
+        } catch (IllegalArgumentException ignored) {
+        }
+      }
+    }
+
+    ConfigurationSection msgSec = sec.getConfigurationSection("messages");
+    this.msgNotEnoughMoney = msgSec != null ? msgSec.getString("not_enough_money", "") : "";
+    this.msgIdentifySuccess = msgSec != null ? msgSec.getString("identify_success", "") : "";
+    this.msgIdentifyEmpty = msgSec != null ? msgSec.getString("identify_empty", "") : "";
+
+    ConfigurationSection effSec = sec.getConfigurationSection("effects");
+    this.identifySuccessSound = parseSound(effSec != null ? effSec.getString("on_identify_success_sound") : null);
+    this.identifyEmptySound = parseSound(effSec != null ? effSec.getString("on_identify_empty_sound") : null);
+  }
+
+  private String color(String s) {
+    return ChatColor.translateAlternateColorCodes('&', s);
+  }
+
+  private Sound parseSound(String name) {
+    if (name == null || name.isEmpty()) return null;
+    try {
+      return Sound.valueOf(name);
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+  }
+
+  /** Create a new unidentified treasure map item. */
+  public ItemStack createUnidentified() {
+    ItemStack item = new ItemStack(Material.PAPER);
+    applyUnidentified(item);
+    UUID id = getId(item);
+    if (id != null) {
+      try {
+        repo.upsert(id, MapState.UNIDENTIFIED, null);
+      } catch (Exception ignored) {}
+    }
+    return item;
+  }
+
+  private void ensureId(ItemMeta meta) {
+    PersistentDataContainer pdc = meta.getPersistentDataContainer();
+    if (pdc.get(idKey, PersistentDataType.STRING) == null) {
+      pdc.set(idKey, PersistentDataType.STRING, UUID.randomUUID().toString());
+    }
+  }
+
+  private UUID getId(ItemMeta meta) {
+    String id = meta.getPersistentDataContainer().get(idKey, PersistentDataType.STRING);
+    if (id == null) return null;
+    try {
+      return UUID.fromString(id);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private void applyUnidentified(ItemStack item) {
+    ItemMeta meta = item.getItemMeta();
+    if (meta == null) return;
+    ensureId(meta);
+    meta.setDisplayName(color(unidentifiedName));
+    List<String> lore = new ArrayList<>();
+    for (String line : unidentifiedLore) lore.add(color(line));
+    meta.setLore(lore);
+    PersistentDataContainer pdc = meta.getPersistentDataContainer();
+    pdc.set(stateKey, PersistentDataType.STRING, MapState.UNIDENTIFIED.name());
+    pdc.remove(lairKey);
+    meta.setUnbreakable(true);
+    meta.addEnchant(Enchantment.DURABILITY, 10, true);
+    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+    item.setItemMeta(meta);
+  }
+
+  private void applyAsh(ItemStack item) {
+    ItemMeta meta = item.getItemMeta();
+    if (meta == null) return;
+    ensureId(meta);
+    meta.setDisplayName(color(ashName));
+    List<String> lore = new ArrayList<>();
+    for (String line : ashLore) lore.add(color(line));
+    meta.setLore(lore);
+    PersistentDataContainer pdc = meta.getPersistentDataContainer();
+    pdc.set(stateKey, PersistentDataType.STRING, MapState.ASH.name());
+    pdc.remove(lairKey);
+    meta.setUnbreakable(true);
+    meta.addEnchant(Enchantment.DURABILITY, 10, true);
+    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+    item.setItemMeta(meta);
+  }
+
+  private void applyIdentified(ItemStack item, Lair lair) {
+    ItemMeta meta = item.getItemMeta();
+    if (meta == null) return;
+    ensureId(meta);
+    String name = identifiedNameFormat.replace("{lair}", lairDisplay(lair));
+    meta.setDisplayName(color(name));
+    List<String> lore = new ArrayList<>();
+    lore.add(color(identifiedLoreHeader));
+    List<String> lines = lairLore.getOrDefault(lair, List.of());
+    for (String line : lines) lore.add(color(line));
+    if (!identifiedTradeNote.isEmpty()) lore.add(color(identifiedTradeNote));
+    meta.setLore(lore);
+    PersistentDataContainer pdc = meta.getPersistentDataContainer();
+    pdc.set(stateKey, PersistentDataType.STRING, MapState.IDENTIFIED.name());
+    pdc.set(lairKey, PersistentDataType.STRING, lair.name());
+    meta.setUnbreakable(true);
+    meta.addEnchant(Enchantment.DURABILITY, 10, true);
+    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+    item.setItemMeta(meta);
+  }
+
+  private Lair rollLair() {
+    double r = random.nextDouble() * totalWeight;
+    double acc = 0;
+    for (Weighted w : weights) {
+      acc += w.weight;
+      if (r < acc) return w.lair;
+    }
+    return null;
+  }
+
+  /** Human readable lair name. */
+  public String lairDisplay(Lair lair) {
+    return switch (lair) {
+      case INFERNAL -> "Infernal Lair";
+      case HELL -> "Hell Lair";
+      case BLOOD -> "Blood Lair";
+      case KRAKEN -> "Kraken's Lair";
+    };
+  }
+
+  public MapState getState(ItemStack item) {
+    ItemMeta meta = item.getItemMeta();
+    if (meta == null) return null;
+    String state = meta.getPersistentDataContainer().get(stateKey, PersistentDataType.STRING);
+    if (state == null) return null;
+    try {
+      return MapState.valueOf(state);
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+  }
+
+  public Lair getLair(ItemStack item) {
+    ItemMeta meta = item.getItemMeta();
+    if (meta == null) return null;
+    String lair = meta.getPersistentDataContainer().get(lairKey, PersistentDataType.STRING);
+    if (lair == null) return null;
+    try {
+      return Lair.valueOf(lair);
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+  }
+
+  public boolean isUnidentified(ItemStack item) {
+    return getState(item) == MapState.UNIDENTIFIED;
+  }
+
+  public boolean isIdentified(ItemStack item) {
+    return getState(item) == MapState.IDENTIFIED;
+  }
+
+  public boolean isAsh(ItemStack item) {
+    return getState(item) == MapState.ASH;
+  }
+
+  public UUID getId(ItemStack item) {
+    ItemMeta meta = item.getItemMeta();
+    if (meta == null) return null;
+    return getId(meta);
+  }
+
+  /** Mark map as spent in persistent storage. */
+  public void markSpent(ItemStack item) {
+    UUID id = getId(item);
+    if (id != null) {
+      try {
+        repo.upsert(id, MapState.SPENT, getLair(item));
+      } catch (Exception ignored) {}
+    }
+  }
+
+  /** Identify the map in-place and charge the player. */
+  public void identify(Player player, ItemStack item) {
+    if (!isUnidentified(item)) {
+      return;
+    }
+    if (economy.getBalance(player) < identifyCost) {
+      String msg = msgNotEnoughMoney.replace("${cost}", currencySymbol + identifyCost);
+      player.sendMessage(color(msg));
+      return;
+    }
+    economy.withdrawPlayer(player, identifyCost);
+    Lair result = rollLair();
+    if (result == null) {
+      applyAsh(item);
+      player.sendMessage(color(msgIdentifyEmpty));
+      if (identifyEmptySound != null)
+        player.playSound(player.getLocation(), identifyEmptySound, 1f, 1f);
+      UUID id = getId(item);
+      if (id != null) {
+        try { repo.upsert(id, MapState.ASH, null); } catch (Exception ignored) {}
+      }
+    } else {
+      applyIdentified(item, result);
+      String msg = msgIdentifySuccess.replace("{lair}", lairDisplay(result));
+      player.sendMessage(color(msg));
+      if (identifySuccessSound != null)
+        player.playSound(player.getLocation(), identifySuccessSound, 1f, 1f);
+      UUID id = getId(item);
+      if (id != null) {
+        try { repo.upsert(id, MapState.IDENTIFIED, result); } catch (Exception ignored) {}
+      }
+    }
+  }
+
+  public double identifyCost() {
+    return identifyCost;
+  }
+
+  public String currencySymbol() {
+    return currencySymbol;
+  }
+
+  // Debug helpers exposing expected unidentified map metadata
+  public String debugUnidentifiedName() {
+    return unidentifiedName;
+  }
+
+  public List<String> debugUnidentifiedLore() {
+    return unidentifiedLore;
+  }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -76,3 +76,111 @@ category_scaling:
   TREASURE:
     mode: EXP
     beta: 0.0040
+treasure_maps:
+  identify_cost: 5000000
+  outcomes:
+    EMPTY: 70.0
+    INFERNAL: 15.0
+    HELL: 7.5
+    BLOOD: 5.0
+    KRAKEN: 2.5
+  effects:
+    on_identify_success_sound: ENTITY_EXPERIENCE_ORB_PICKUP
+    on_identify_empty_sound: BLOCK_FIRE_EXTINGUISH
+    on_confirm_sound: UI_TOAST_CHALLENGE_COMPLETE
+  lairs:
+    INFERNAL:
+      warp: infernal_lair
+      time_limit_seconds: 600
+      spawn:
+        count: 3
+        boss_pool:
+          - Infernal_Boss_A
+          - Infernal_Boss_B
+          - Infernal_Boss_C
+        spawn_cmd_template: "mm mobs spawn {mob} 1 {world} {x} {y} {z}"
+        spawn_delay_ticks: 20
+      lore_lines:
+        - "&cInfernal Lair"
+        - "&7A gateway bathed in embers and ash."
+        - "&7Face three horrors from the inferno."
+    HELL:
+      warp: hell_lair
+      time_limit_seconds: 600
+      spawn:
+        count: 3
+        boss_pool:
+          - Hell_Boss_A
+          - Hell_Boss_B
+          - Hell_Boss_C
+        spawn_cmd_template: "mm mobs spawn {mob} 1 {world} {x} {y} {z}"
+        spawn_delay_ticks: 20
+      lore_lines:
+        - "&4Hell Lair"
+        - "&7Sulfur, screams, and searing chains."
+        - "&7Three fiends await."
+    BLOOD:
+      warp: blood_lair
+      time_limit_seconds: 600
+      spawn:
+        count: 3
+        boss_pool:
+          - Blood_Boss_A
+          - Blood_Boss_B
+          - Blood_Boss_C
+        spawn_cmd_template: "mm mobs spawn {mob} 1 {world} {x} {y} {z}"
+        spawn_delay_ticks: 20
+      lore_lines:
+        - "&cBlood Lair"
+        - "&7A sacrificial pit slick with crimson rites."
+        - "&7Three aberrations stir."
+    KRAKEN:
+      warp: kraken_lair
+      time_limit_seconds: 600
+      spawn:
+        count: 1
+        boss_pool:
+          - Kraken
+        spawn_cmd_template: "mm mobs spawn {mob} 1 {world} {x} {y} {z}"
+        spawn_delay_ticks: 20
+      lore_lines:
+        - "&bKraken's Lair"
+        - "&7The sea holds its breath. The abyss watches back."
+        - "&7One leviathan. One chance."
+  items:
+    unidentified_name: "&aUnidentified Treasure Map"
+    unidentified_lore:
+      - "&8&oThis map might lead to &bhidden treasure&8&o..."
+      - "&8&oBring it to the &bPirate King &8&ofor identification."
+    ash_name: "&8Ash Map"
+    ash_lore:
+      - "&7The ink fades into nothing."
+      - "&8The sea keeps its secrets."
+    identified_name_format: "&e{lair} Treasure Map"
+    identified_lore_header: "&8— — — — — — — — — —"
+    identified_trade_note: "&7This map can be traded."
+  messages:
+    not_enough_money: "&cYou need &e${cost}&c to identify this map."
+    identify_success: "&aThe map points to: &e{lair}&a!"
+    identify_empty: "&7The map turns to ash in your hands."
+    lair_occupied: "&cThat lair is currently occupied. Please wait."
+    confirm_start: "&aBounty started: &e{lair}&a. You have &e10:00&a!"
+    discard: "&7Map returned to your inventory."
+    timeout: "&eTime's up! You are returned to spawn."
+    death: "&cYou were slain during the bounty."
+    ash_cannot_use: "&7Ash maps cannot be used."
+    inserted_identified: "&7Identified map detected. Choose: &aConfirm Bounty &7or &7Discard&7."
+    warp_failed: "&cTeleport failed. Try again."
+    lair_released: "&7The lair has been released."
+  buttons:
+    identify: "&6Identify (&e${cost}&6)"
+    confirm_bounty: "&aConfirm Bounty"
+    discard: "&7Discard"
+    occupied: "&cOccupied"
+  titles:
+    start_title: "&aBounty Begun!"
+    start_subtitle: "&e{lair} &7— 10:00 on the clock"
+    timeout_title: "&eTime's Up!"
+    timeout_subtitle: "&7Returning to spawn…"
+    death_title: "&cBounty Failed"
+    death_subtitle: "&7You were slain."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -24,6 +24,10 @@ commands:
     description: View fishing quests
     usage: /fishing_quests
     permission: fishing.use
+  pirate_king:
+    description: Access Pirate King bounty menu
+    usage: /pirate_king
+    permission: fishing.pirateking
 permissions:
   fishing.admin:
     description: Allows editing loot and quests
@@ -34,3 +38,6 @@ permissions:
   fishing.use:
     description: Allows accessing fishing features
     default: true
+  fishing.pirateking:
+    description: Allows using Pirate King features
+    default: false


### PR DESCRIPTION
## Summary
- add a help item labeled "How Treasure Maps Work" to Pirate King menu
- show basic instructions on using treasure maps within the GUI
- restrict Pirate King menu to a single treasure map slot and reject non-map items or stacks
- add detailed debug logging of item name, lore, and expected metadata when a map is rejected

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a094ef0550832aaaad4b405bcd7902