### PR TITLE
Clear bounty lair locks between server restarts

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -128,6 +128,11 @@ public final class FishingPlugin extends JavaPlugin {
             return;
         }
         try {
+            lairLockRepo.releaseAll();
+        } catch (SQLException e) {
+            getLogger().warning("Failed to clear lair locks: " + e.getMessage());
+        }
+        try {
             seedDefaultLoot();
         } catch (SQLException e) {
             getLogger().warning("Failed to seed default loot: " + e.getMessage());
@@ -354,6 +359,13 @@ public final class FishingPlugin extends JavaPlugin {
                 levelService.saveProfile(p);
                 antiCheatService.reset(p.getUniqueId());
             });
+        }
+        if (lairLockRepo != null) {
+            try {
+                lairLockRepo.releaseAll();
+            } catch (SQLException e) {
+                getLogger().warning("Failed to clear lair locks: " + e.getMessage());
+            }
         }
         if (database != null) {
             database.close();

--- a/src/main/java/org/maks/fishingPlugin/data/LairLockRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/LairLockRepo.java
@@ -58,6 +58,14 @@ public class LairLockRepo {
     }
   }
 
+  /** Release all lair locks. */
+  public void releaseAll() throws SQLException {
+    String sql = "DELETE FROM fishing_lair_lock";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
+  }
+
   /** Remove locks older than cutoffMillis epoch. */
   public int cleanupOlderThan(long cutoffMillis) throws SQLException {
     String sql = "DELETE FROM fishing_lair_lock WHERE started_at < ?";


### PR DESCRIPTION
## Summary
- add method to purge all bounty lair locks
- clear stored lair locks on plugin startup and shutdown

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a2b31448832abaaa653f10ba0f66