### PR TITLE
Clear bounty lair locks and consume bounty maps on confirmation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>mythicmobs-repo</id>
+            <url>https://mvn.lumine.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
         <dependencies>
@@ -102,6 +106,12 @@
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
                 <version>8.0.33</version>
+            </dependency>
+            <dependency>
+                <groupId>io.lumine</groupId>
+                <artifactId>Mythic-Dist</artifactId>
+                <version>5.5.1</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
   </project>

--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -128,6 +128,11 @@ public final class FishingPlugin extends JavaPlugin {
             return;
         }
         try {
+            lairLockRepo.releaseAll();
+        } catch (SQLException e) {
+            getLogger().warning("Failed to clear lair locks: " + e.getMessage());
+        }
+        try {
             seedDefaultLoot();
         } catch (SQLException e) {
             getLogger().warning("Failed to seed default loot: " + e.getMessage());
@@ -354,6 +359,13 @@ public final class FishingPlugin extends JavaPlugin {
                 levelService.saveProfile(p);
                 antiCheatService.reset(p.getUniqueId());
             });
+        }
+        if (lairLockRepo != null) {
+            try {
+                lairLockRepo.releaseAll();
+            } catch (SQLException e) {
+                getLogger().warning("Failed to clear lair locks: " + e.getMessage());
+            }
         }
         if (database != null) {
             database.close();

--- a/src/main/java/org/maks/fishingPlugin/data/LairLockRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/LairLockRepo.java
@@ -58,6 +58,14 @@ public class LairLockRepo {
     }
   }
 
+  /** Release all lair locks. */
+  public void releaseAll() throws SQLException {
+    String sql = "DELETE FROM fishing_lair_lock";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
+  }
+
   /** Remove locks older than cutoffMillis epoch. */
   public int cleanupOlderThan(long cutoffMillis) throws SQLException {
     String sql = "DELETE FROM fishing_lair_lock WHERE started_at < ?";

--- a/src/main/java/org/maks/fishingPlugin/gui/PirateKingMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/PirateKingMenu.java
@@ -242,6 +242,7 @@ public class PirateKingMenu implements Listener {
       } else if (map != null && mapService.isIdentified(map)) {
         if (bountyService.confirm(player, map)) {
           inv.setItem(13, null);
+          player.closeInventory();
         }
       }
       Bukkit.getScheduler().runTask(plugin, () -> refresh(player, inv));

--- a/src/main/java/org/maks/fishingPlugin/service/BountyService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/BountyService.java
@@ -12,11 +12,11 @@ import org.bukkit.Location;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.Sound;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
@@ -171,7 +171,8 @@ public class BountyService implements Listener {
     occupied.put(lair, player.getUniqueId());
     playerLair.put(player.getUniqueId(), lair);
     mapService.markSpent(map);
-    player.closeInventory();
+    map.setType(Material.AIR);
+    map.setAmount(0);
     if (!teleportService.teleport(spec.warp(), player)) {
       freeLair(lair);
       playerLair.remove(player.getUniqueId());
@@ -265,7 +266,10 @@ public class BountyService implements Listener {
   }
 
   private void success(UUID playerId) {
-    release(playerId, msgSuccess, titleSuccess, titleSuccessSub);
+    cancelTasks(playerId);
+    activeMobs.remove(playerId);
+    Bukkit.getScheduler().runTaskLater(plugin,
+        () -> release(playerId, msgSuccess, titleSuccess, titleSuccessSub), 300L);
   }
 
   private void release(UUID playerId, String message, String title, String subtitle) {
@@ -300,13 +304,14 @@ public class BountyService implements Listener {
   }
 
   @EventHandler
-  public void onMobDeath(EntityDeathEvent e) {
+  public void onMobDeath(io.lumine.mythic.bukkit.events.MythicMobDeathEvent e) {
     Player killer = e.getEntity().getKiller();
-    if (killer == null) return;
+    if (killer == null) {
+      return;
+    }
     Map<String, Integer> counts = activeMobs.get(killer.getUniqueId());
     if (counts == null) return;
-    if (!e.getEntity().hasMetadata("MythicType")) return;
-    String type = e.getEntity().getMetadata("MythicType").get(0).asString();
+    String type = e.getMob().getType().getInternalName();
     Integer remaining = counts.get(type);
     if (remaining == null) return;
     if (remaining <= 1) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: FishingPlugin
 main: org.maks.fishingPlugin.FishingPlugin
 version: 0.0.1
 api-version: 1.20
+depend: [MythicMobs]
 softdepend: [PlaceholderAPI, EliteLootbox, WorldGuard, Citizens]
 commands:
   fishing:


### PR DESCRIPTION
## Summary
- add method to purge all bounty lair locks
- clear stored lair locks on plugin startup and shutdown
- consume bounty map items when a player confirms a bounty
- ensure bounty GUI closes only after the map is removed so it doesn't return to the player's inventory
- listen for MythicMob boss deaths and return players to spawn 15 seconds later
- fix MythicMob kill tracking and declare MythicMobs as a plugin dependency
- detect MythicMob deaths using Bukkit's killer lookup to count player kills reliably

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a2b31448832abaaa653f10ba0f66