### PR TITLE
Add bounty reward editor GUI

### DIFF
--- a/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
+++ b/src/main/java/org/maks/fishingPlugin/FishingPlugin.java
@@ -46,6 +46,7 @@ import org.maks.fishingPlugin.gui.QuestMenu;
 import org.maks.fishingPlugin.gui.AdminLootEditorMenu;
 import org.maks.fishingPlugin.gui.AdminQuestEditorMenu;
 import org.maks.fishingPlugin.gui.PirateKingMenu;
+import org.maks.fishingPlugin.gui.AdminBountyRewardMenu;
 import org.maks.fishingPlugin.command.QuickSellCommand;
 import org.maks.fishingPlugin.command.GiveRodCommand;
 import org.maks.fishingPlugin.command.AdminRodCommand;
@@ -53,6 +54,8 @@ import org.maks.fishingPlugin.command.QuestCommand;
 import org.maks.fishingPlugin.command.PirateKingCommand;
 import org.maks.fishingPlugin.service.TreasureMapService;
 import org.maks.fishingPlugin.service.BountyService;
+import org.maks.fishingPlugin.service.BountyRewardService;
+import org.maks.fishingPlugin.data.BountyRewardRepo;
 import net.milkbowl.vault.economy.Economy;
 
 public final class FishingPlugin extends JavaPlugin {
@@ -77,6 +80,7 @@ public final class FishingPlugin extends JavaPlugin {
     private ProfileRepo profileRepo;
     private TreasureMapRepo treasureMapRepo;
     private LairLockRepo lairLockRepo;
+    private BountyRewardRepo bountyRewardRepo;
     private MirrorItemService mirrorItemService;
     private boolean hasEliteLootbox;
     private boolean hasWorldGuard;
@@ -113,6 +117,7 @@ public final class FishingPlugin extends JavaPlugin {
         this.profileRepo = new ProfileRepo(ds);
         this.treasureMapRepo = new TreasureMapRepo(ds);
         this.lairLockRepo = new LairLockRepo(ds);
+        this.bountyRewardRepo = new BountyRewardRepo(ds);
         try {
             lootRepo.init();
             mirrorItemRepo.init();
@@ -122,6 +127,7 @@ public final class FishingPlugin extends JavaPlugin {
             profileRepo.init();
             treasureMapRepo.init();
             lairLockRepo.init();
+            bountyRewardRepo.init();
         } catch (SQLException e) {
             getLogger().severe("Failed to initialize database tables: " + e.getMessage());
             getServer().getPluginManager().disablePlugin(this);
@@ -303,11 +309,13 @@ public final class FishingPlugin extends JavaPlugin {
         ShopMenu shopMenu = new ShopMenu(this, requiredPlayerLevel);
         QuestMenu questMenu = new QuestMenu(questService);
         AdminQuestEditorMenu adminQuestMenu = new AdminQuestEditorMenu(this, questService, questRepo);
+        BountyRewardService bountyRewardService = new BountyRewardService(this, bountyRewardRepo);
+        AdminBountyRewardMenu adminBountyMenu = new AdminBountyRewardMenu(this, bountyRewardService);
         AdminLootEditorMenu adminMenu = new AdminLootEditorMenu(this, lootService, lootRepo, paramRepo,
-            quickSellService, adminQuestMenu, mirrorItemRepo, mirrorItemService);
+            quickSellService, adminQuestMenu, mirrorItemRepo, mirrorItemService, adminBountyMenu);
         MainMenu mainMenu = new MainMenu(shopMenu, teleportService, requiredPlayerLevel);
         TreasureMapService treasureMapService = new TreasureMapService(this, economy, treasureMapRepo);
-        BountyService bountyService = new BountyService(this, teleportService, treasureMapService, lairLockRepo);
+        BountyService bountyService = new BountyService(this, teleportService, treasureMapService, lairLockRepo, bountyRewardService);
         PirateKingMenu pirateKingMenu = new PirateKingMenu(this, treasureMapService, bountyService);
         getCommand("fishing").setExecutor(new FishingCommand(mainMenu, adminMenu, requiredPlayerLevel));
         getCommand("fishsell").setExecutor(new QuickSellCommand(quickSellMenu));
@@ -321,6 +329,7 @@ public final class FishingPlugin extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(questMenu, this);
         Bukkit.getPluginManager().registerEvents(adminMenu, this);
         Bukkit.getPluginManager().registerEvents(adminQuestMenu, this);
+        Bukkit.getPluginManager().registerEvents(adminBountyMenu, this);
         Bukkit.getPluginManager().registerEvents(pirateKingMenu, this);
         Bukkit.getPluginManager().registerEvents(bountyService, this);
 

--- a/src/main/java/org/maks/fishingPlugin/data/BountyRewardRepo.java
+++ b/src/main/java/org/maks/fishingPlugin/data/BountyRewardRepo.java
@@ -1,0 +1,60 @@
+package org.maks.fishingPlugin.data;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.maks.fishingPlugin.model.BountyReward;
+import org.maks.fishingPlugin.service.TreasureMapService;
+
+/** Repository for bounty rewards per lair. */
+public class BountyRewardRepo {
+
+  private final DataSource dataSource;
+
+  public BountyRewardRepo(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  /** Create backing table if missing. */
+  public void init() throws SQLException {
+    String sql = "CREATE TABLE IF NOT EXISTS fishing_bounty_reward (" +
+        "lair VARCHAR(16) PRIMARY KEY, " +
+        "reward TEXT NOT NULL" +
+        ")";
+    try (Connection con = dataSource.getConnection(); Statement st = con.createStatement()) {
+      st.executeUpdate(sql);
+    }
+  }
+
+  public List<BountyReward> findAll() throws SQLException {
+    String sql = "SELECT lair, reward FROM fishing_bounty_reward";
+    List<BountyReward> list = new ArrayList<>();
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql);
+         ResultSet rs = ps.executeQuery()) {
+      while (rs.next()) {
+        TreasureMapService.Lair lair = TreasureMapService.Lair.valueOf(rs.getString(1));
+        String data = rs.getString(2);
+        list.add(new BountyReward(lair, data));
+      }
+    }
+    return list;
+  }
+
+  /** Insert or update reward for a lair. */
+  public void upsert(BountyReward reward) throws SQLException {
+    String sql = "INSERT INTO fishing_bounty_reward(lair,reward) VALUES(?,?) " +
+        "ON DUPLICATE KEY UPDATE reward=VALUES(reward)";
+    try (Connection con = dataSource.getConnection();
+         PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, reward.lair().name());
+      ps.setString(2, reward.rewardData());
+      ps.executeUpdate();
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/AdminBountyRewardMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/AdminBountyRewardMenu.java
@@ -1,0 +1,144 @@
+package org.maks.fishingPlugin.gui;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.java.JavaPlugin;
+import net.kyori.adventure.text.Component;
+import org.maks.fishingPlugin.service.BountyRewardService;
+import org.maks.fishingPlugin.service.TreasureMapService;
+
+/** Inventory menu for editing bounty rewards. */
+public class AdminBountyRewardMenu implements Listener {
+
+  private final JavaPlugin plugin;
+  private final BountyRewardService rewardService;
+  private final Map<UUID, TreasureMapService.Lair> editors = new HashMap<>();
+
+  public AdminBountyRewardMenu(JavaPlugin plugin, BountyRewardService rewardService) {
+    this.plugin = plugin;
+    this.rewardService = rewardService;
+  }
+
+  private Inventory createInventory() {
+    Map<Integer, TreasureMapService.Lair> map = new HashMap<>();
+    Inventory inv = Bukkit.createInventory(new Holder(map), 27, "Bounty Rewards");
+    int slot = 0;
+    for (TreasureMapService.Lair lair : TreasureMapService.Lair.values()) {
+      ItemStack item = new ItemStack(Material.PAPER);
+      ItemMeta meta = item.getItemMeta();
+      if (meta != null) {
+        String name = lair.name().substring(0, 1) + lair.name().substring(1).toLowerCase();
+        meta.displayName(Component.text(name));
+        java.util.List<Component> lore = new java.util.ArrayList<>();
+        ItemStack[] rewards = rewardService.getItems(lair);
+        if (rewards.length > 0) {
+          lore.add(Component.text("Rewards: " + rewards.length + " item(s)"));
+        } else {
+          lore.add(Component.text("No rewards"));
+        }
+        lore.add(Component.text("Click to edit"));
+        meta.lore(lore);
+        item.setItemMeta(meta);
+      }
+      inv.setItem(slot, item);
+      map.put(slot, lair);
+      slot++;
+    }
+    return inv;
+  }
+
+  /** Open bounty reward menu. */
+  public void open(Player player) {
+    player.openInventory(createInventory());
+  }
+
+  private void openItemEditor(Player player, TreasureMapService.Lair lair) {
+    Inventory inv = Bukkit.createInventory(new ItemEditorHolder(), 27, lair.name() + " Reward");
+    ItemStack confirm = new ItemStack(Material.LIME_CONCRETE);
+    ItemMeta cm = confirm.getItemMeta();
+    if (cm != null) {
+      cm.displayName(Component.text("Confirm"));
+      confirm.setItemMeta(cm);
+    }
+    inv.setItem(26, confirm);
+    ItemStack[] items = rewardService.getItems(lair);
+    for (int i = 0; i < Math.min(items.length, 26); i++) {
+      inv.setItem(i, items[i]);
+    }
+    editors.put(player.getUniqueId(), lair);
+    player.openInventory(inv);
+    player.sendMessage("Place reward items and click the green block to confirm.");
+  }
+
+  @EventHandler
+  public void onClick(InventoryClickEvent event) {
+    if (event.getInventory().getHolder() instanceof Holder holder) {
+      event.setCancelled(true);
+      TreasureMapService.Lair lair = holder.map.get(event.getRawSlot());
+      if (lair != null) {
+        openItemEditor((Player) event.getWhoClicked(), lair);
+      }
+      return;
+    }
+
+    if (event.getView().getTopInventory().getHolder() instanceof ItemEditorHolder) {
+      Player player = (Player) event.getWhoClicked();
+      if (event.getClickedInventory() != null
+          && event.getClickedInventory().getHolder() instanceof ItemEditorHolder) {
+        int slot = event.getRawSlot();
+        if (slot == 26) {
+          event.setCancelled(true);
+          TreasureMapService.Lair lair = editors.remove(player.getUniqueId());
+          if (lair != null) {
+            Inventory top = event.getView().getTopInventory();
+            java.util.List<ItemStack> items = new java.util.ArrayList<>();
+            for (int i = 0; i < 26; i++) {
+              ItemStack it = top.getItem(i);
+              if (it != null && !it.getType().isAir()) {
+                items.add(it);
+              }
+            }
+            rewardService.setItems(lair, items.toArray(new ItemStack[0]));
+            player.sendMessage("Bounty reward saved for " + lair.name().toLowerCase());
+          }
+          player.closeInventory();
+        } else if (slot < 26) {
+          event.setCancelled(false);
+        }
+      } else {
+        event.setCancelled(false);
+      }
+    }
+  }
+
+  @EventHandler
+  public void onClose(InventoryCloseEvent event) {
+    if (event.getInventory().getHolder() instanceof ItemEditorHolder) {
+      Player player = (Player) event.getPlayer();
+      editors.remove(player.getUniqueId());
+      Bukkit.getScheduler().runTask(plugin, () -> open(player));
+    }
+  }
+
+  private static class Holder implements InventoryHolder {
+    final Map<Integer, TreasureMapService.Lair> map;
+    Holder(Map<Integer, TreasureMapService.Lair> map) { this.map = map; }
+    @Override public Inventory getInventory() { return null; }
+  }
+
+  private static class ItemEditorHolder implements InventoryHolder {
+    @Override public Inventory getInventory() { return null; }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/gui/AdminLootEditorMenu.java
+++ b/src/main/java/org/maks/fishingPlugin/gui/AdminLootEditorMenu.java
@@ -32,6 +32,7 @@ import org.maks.fishingPlugin.service.LootService;
 import org.maks.fishingPlugin.service.MirrorItemService;
 import org.maks.fishingPlugin.service.QuickSellService;
 import org.maks.fishingPlugin.util.ItemSerialization;
+import org.maks.fishingPlugin.gui.AdminBountyRewardMenu;
 
 /** Inventory based admin editor for loot and scaling. */
 public class AdminLootEditorMenu implements Listener {
@@ -44,6 +45,7 @@ public class AdminLootEditorMenu implements Listener {
   private final AdminQuestEditorMenu questMenu;
   private final MirrorItemRepo mirrorItemRepo;
   private final MirrorItemService mirrorItemService;
+  private final AdminBountyRewardMenu bountyMenu;
 
   /** Pending chat editors mapped by player. */
   private final Map<UUID, Editor> editors = new HashMap<>();
@@ -54,7 +56,8 @@ public class AdminLootEditorMenu implements Listener {
 
   public AdminLootEditorMenu(JavaPlugin plugin, LootService lootService, LootRepo lootRepo,
       ParamRepo paramRepo, QuickSellService quickSellService, AdminQuestEditorMenu questMenu,
-      MirrorItemRepo mirrorItemRepo, MirrorItemService mirrorItemService) {
+      MirrorItemRepo mirrorItemRepo, MirrorItemService mirrorItemService,
+      AdminBountyRewardMenu bountyMenu) {
     this.plugin = plugin;
     this.lootService = lootService;
     this.lootRepo = lootRepo;
@@ -63,6 +66,7 @@ public class AdminLootEditorMenu implements Listener {
     this.questMenu = questMenu;
     this.mirrorItemRepo = mirrorItemRepo;
     this.mirrorItemService = mirrorItemService;
+    this.bountyMenu = bountyMenu;
   }
 
   enum Type {
@@ -100,6 +104,7 @@ public class AdminLootEditorMenu implements Listener {
     inv.setItem(18, button(Material.GLASS, "Add Mirror Item"));
     inv.setItem(20, button(Material.SUNFLOWER, "Edit Economy"));
     inv.setItem(22, button(Material.CHEST, "Edit Category Weights"));
+    inv.setItem(24, button(Material.DIAMOND_SWORD, "Edit Bounty Rewards"));
     return inv;
   }
 
@@ -666,6 +671,8 @@ public class AdminLootEditorMenu implements Listener {
           openEconomy(player);
         } else if (slot == 22) {
           openCatWeights(player);
+        } else if (slot == 24) {
+          bountyMenu.open(player);
         }
       }
       case ADD_ITEMS -> {

--- a/src/main/java/org/maks/fishingPlugin/model/BountyReward.java
+++ b/src/main/java/org/maks/fishingPlugin/model/BountyReward.java
@@ -1,0 +1,6 @@
+package org.maks.fishingPlugin.model;
+
+import org.maks.fishingPlugin.service.TreasureMapService;
+
+/** Definition of bounty reward for a lair. */
+public record BountyReward(TreasureMapService.Lair lair, String rewardData) {}

--- a/src/main/java/org/maks/fishingPlugin/service/BountyRewardService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/BountyRewardService.java
@@ -1,0 +1,71 @@
+package org.maks.fishingPlugin.service;
+
+import java.sql.SQLException;
+import java.util.EnumMap;
+import java.util.Map;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.maks.fishingPlugin.data.BountyRewardRepo;
+import org.maks.fishingPlugin.model.BountyReward;
+import org.maks.fishingPlugin.util.ItemSerialization;
+import org.maks.fishingPlugin.service.TreasureMapService;
+
+/**
+ * Manages bounty reward definitions and granting.
+ */
+public class BountyRewardService {
+
+  private final JavaPlugin plugin;
+  private final BountyRewardRepo repo;
+  private final Map<TreasureMapService.Lair, String> rewards =
+      new EnumMap<>(TreasureMapService.Lair.class);
+
+  public BountyRewardService(JavaPlugin plugin, BountyRewardRepo repo) {
+    this.plugin = plugin;
+    this.repo = repo;
+    try {
+      for (BountyReward r : repo.findAll()) {
+        rewards.put(r.lair(), r.rewardData());
+      }
+    } catch (SQLException e) {
+      plugin.getLogger().warning("Failed to load bounty rewards: " + e.getMessage());
+    }
+  }
+
+  /** Get reward items for a lair. */
+  public ItemStack[] getItems(TreasureMapService.Lair lair) {
+    String data = rewards.getOrDefault(lair, "");
+    try {
+      return ItemSerialization.fromBase64List(data);
+    } catch (Exception e) {
+      return new ItemStack[0];
+    }
+  }
+
+  /** Set reward items for a lair. */
+  public void setItems(TreasureMapService.Lair lair, ItemStack[] items) {
+    String data = "";
+    if (items.length > 0) {
+      data = ItemSerialization.toBase64(items);
+    }
+    rewards.put(lair, data);
+    try {
+      repo.upsert(new BountyReward(lair, data));
+    } catch (SQLException e) {
+      plugin.getLogger().warning("Failed to save bounty reward: " + e.getMessage());
+    }
+  }
+
+  /** Grant rewards for completing a lair. */
+  public void give(Player player, TreasureMapService.Lair lair) {
+    ItemStack[] items = getItems(lair);
+    if (items.length == 0) {
+      return;
+    }
+    Map<Integer, ItemStack> leftover = player.getInventory().addItem(items);
+    for (ItemStack it : leftover.values()) {
+      player.getWorld().dropItem(player.getLocation(), it);
+    }
+  }
+}

--- a/src/main/java/org/maks/fishingPlugin/service/BountyService.java
+++ b/src/main/java/org/maks/fishingPlugin/service/BountyService.java
@@ -22,6 +22,8 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import org.maks.fishingPlugin.service.BountyRewardService;
+
 /**
  * Handles bounty confirmations and lair instances.
  */
@@ -36,6 +38,7 @@ public class BountyService implements Listener {
   private final TeleportService teleportService;
   private final TreasureMapService mapService;
   private final org.maks.fishingPlugin.data.LairLockRepo lockRepo;
+  private final BountyRewardService rewardService;
   private final Map<TreasureMapService.Lair, LairSpec> lairSpecs = new EnumMap<>(TreasureMapService.Lair.class);
   private final Map<TreasureMapService.Lair, UUID> occupied = new EnumMap<>(TreasureMapService.Lair.class);
   private final Map<UUID, TreasureMapService.Lair> playerLair = new HashMap<>();
@@ -65,11 +68,12 @@ public class BountyService implements Listener {
   private final Sound confirmSound;
 
   public BountyService(JavaPlugin plugin, TeleportService teleportService, TreasureMapService mapService,
-      org.maks.fishingPlugin.data.LairLockRepo lockRepo) {
+      org.maks.fishingPlugin.data.LairLockRepo lockRepo, BountyRewardService rewardService) {
     this.plugin = plugin;
     this.teleportService = teleportService;
     this.mapService = mapService;
     this.lockRepo = lockRepo;
+    this.rewardService = rewardService;
 
     var lairSec = plugin.getConfig().getConfigurationSection("treasure_maps.lairs");
     if (lairSec != null) {
@@ -278,6 +282,9 @@ public class BountyService implements Listener {
 
     TreasureMapService.Lair lair = playerLair.get(playerId);
     String lairName = lair != null ? mapService.lairDisplay(lair) : "";
+    if (lair != null) {
+      rewardService.give(p, lair);
+    }
     final int[] remaining = {SUCCESS_COUNTDOWN_SECONDS};
     final int[] taskId = new int[1];
     taskId[0] = Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> {


### PR DESCRIPTION
## Summary
- allow admins to configure per-lair bounty rewards
- persist bounty rewards in database and grant after lair completion
- integrate bounty reward editor into admin menu

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bbbb172c832ab3f123769ad004b7